### PR TITLE
Unify templates via base layout

### DIFF
--- a/static/css/custom.css
+++ b/static/css/custom.css
@@ -1,11 +1,69 @@
 /* static/css/custom.css */
 /* 전체 배경/폰트/버튼/카드 등 스타일 개선 */
-body { background: #f6f8fb; color: #22315a; font-family: 'Noto Sans KR', sans-serif; }
+body { background: #f6f8fb; color: #22315a; font-family: 'Noto Sans KR', sans-serif; font-size: 18px; }
 .navbar { background: #1e2b45 !important; }
-.card { border-radius: 1.1rem; box-shadow: 0 4px 24px #0001; }
-.card-head { background: #22315a; color: #fff; font-size: 1.13rem; font-weight: 600; border-radius: 1.1rem 1.1rem 0 0; }
+.card { border-radius: 1.25rem; box-shadow: 0 4px 24px #0001; margin-bottom: 2.5rem; }
+.card-head { background: #22315a; color: #fff; font-size: 1.25rem; font-weight: 600; padding: 1.2rem 2rem; display: flex; align-items: center; gap: .7rem; border-radius: 1.25rem 1.25rem 0 0; }
+.card-body { padding: 2.5rem; }
 .btn-primary, .btn-success { border-radius: 0.75rem; font-weight: 600; }
 .table th, .table td { vertical-align: middle; }
 ::-webkit-scrollbar { width: 8px; background: #eaeaea; }
 ::-webkit-scrollbar-thumb { background: #d1d7e1; border-radius: 5px; }
 .bar-graph, .trend-bar { height: 16px; background: #e9ecef; border-radius: 7px; }
+
+/* Dashboard page */
+#layout { display: flex; height: calc(100vh - 66px); }
+#left { width: 22%; min-width: 300px; max-width: 410px; overflow: auto; padding: 1.6rem 1rem 1rem 1.4rem; }
+#right { flex: 1; overflow: auto; padding: 1.7rem 1.8rem 1.7rem 0.5rem; }
+#drag { width: 7px; background: #dee2e6; cursor: col-resize; min-height: 90vh; }
+.table-responsive { max-height: 46vh; overflow: auto; }
+.table thead { position: sticky; top: 0; z-index: 2; }
+.badge-go { background: #198754; font-size: .8rem; padding: .36rem .85rem; }
+.badge-wait { background: #ffc107; color: #000; font-size: .8rem; padding: .36rem .85rem; }
+.badge-stop { background: #dc3545; font-size: .8rem; padding: .36rem .85rem; }
+.badge-sell-force { background: #dc3545; font-size: .8rem; padding: .36rem .85rem; }
+.badge-sell-sl { background: #fd7e14; color: #000; font-size: .8rem; padding: .36rem .85rem; }
+.badge-sell-tp { background: #0d6efd; font-size: .8rem; padding: .36rem .85rem; }
+.badge-sell-max { background: #20c997; font-size: .8rem; padding: .36rem .85rem; }
+.badge-sell-wait { background: #6c757d; font-size: .8rem; padding: .36rem .85rem; }
+.bar-graph { width: 190px; margin: 0 auto; }
+.trend-bar { width: 170px; margin: 0 auto; }
+.dot { position: absolute; top: 50%; transform: translateY(-50%); width: 15px; height: 15px; border-radius: 50%; }
+.dot.stop { background: #dc3545; left: 0; }
+.dot.entry { background: #6c757d; }
+.dot.take { background: #0d6efd; right: 0; }
+.dot.trend { z-index: 2; }
+.dot.green { background: #198754; }
+.dot.red { background: #dc3545; }
+.dot.yellow { background: #ffc107; }
+.dot.blue { background: #0d6efd; }
+.trend-bar .tick { position: absolute; width: 2px; height: 70%; background: #adb5bd; top: 15%; }
+.trend-bar .tick1 { left: 33%; }
+.trend-bar .tick2 { right: 33%; }
+@media (max-width:1400px){
+  #left { min-width:200px; }
+  #right { padding:1rem; }
+}
+
+/* Strategy page */
+.badge-info { background:#edf3ff; color:#1e2b45; font-size:.97rem; font-weight:500; }
+.bi-info-circle { color:#3468e1; }
+.section-label { font-size:1.22rem; font-weight:700; color:#3753a9; margin-bottom:1.2rem; }
+.form-text { font-size:.99rem; }
+
+/* AI Analysis page */
+.section-label { font-size:1.2rem; font-weight:700; color:#3c63b6; margin-bottom:1.1rem; }
+.btn-ai { background:#3c63b6; color:#fff; }
+.table-hover tbody tr:hover { background:#f1f5fb; }
+
+/* Risk page */
+input[type="number"], input[type="text"] { max-width:220px; }
+.btn-lg { font-size:1.18rem; }
+.bi-shield-check, .bi-bell { font-size:2rem; color:#40b4a8; }
+.card-toolbar { display:flex; gap:1.5rem; flex-wrap:wrap; }
+@media (max-width:1100px){ .container{ max-width:98vw; } }
+
+/* Settings page */
+input[type="password"] { letter-spacing:0.2em; }
+.bi-key, .bi-lock, .bi-person-circle, .bi-telegram { font-size:1.6rem; }
+@media (max-width:1200px){ .container{ max-width:98vw; } }

--- a/templates/ai_analysis.html
+++ b/templates/ai_analysis.html
@@ -1,18 +1,6 @@
 {% extends 'base.html' %}
 {% block title %}UPBIT AutoTrading · 전략별 AI 비교분석{% endblock %}
 {% block content %}
-<style>
-body{background:#f6f8fb;font-size:18px;}
-.navbar{background:#1e2b45;}
-.card-head{background:#22315a;color:#fff;font-size:1.25rem;padding:1.2rem 2rem;display:flex;align-items:center;gap:.7rem;border-radius:1.25rem 1.25rem 0 0;}
-.card{border-radius:1.25rem;margin-bottom:2.5rem;box-shadow:0 4px 24px #0001;}
-.card-body{padding:2.5rem;}
-.section-label{font-size:1.2rem;font-weight:700;color:#3c63b6;margin-bottom:1.1rem;}
-.btn-ai{background:#3c63b6;color:#fff;}
-.container{max-width:1400px;margin-top:56px;}
-th,td{vertical-align:middle;}
-.table-hover tbody tr:hover{background:#f1f5fb;}
-</style>
 <div class="container">
 
   <!-- 분석 범위/실행/이력 -->
@@ -414,5 +402,4 @@ th,td{vertical-align:middle;}
 </div>
 {% endfor %}
 
-<script src="https://cdn.jsdelivr.net/npm/bootstrap@5.3.3/dist/js/bootstrap.bundle.min.js"></script>
 {% endblock %}

--- a/templates/index.html
+++ b/templates/index.html
@@ -1,52 +1,6 @@
 {% extends 'base.html' %}
 {% block title %}UPBIT AutoTrading · 메인 대시보드{% endblock %}
 {% block content %}
-<style>
-body { background:#f6f8fb; font-size:17px; overflow:hidden; }
-.navbar { background:#1e2b45; }
-.card-head {
-  background:#22315a; color:#fff; font-size:1.13rem; font-weight:600;
-  padding:1.05rem 1.5rem; display:flex; align-items:center; gap:.7rem; border-radius:1.1rem 1.1rem 0 0;
-}
-.card { border-radius:1.15rem; box-shadow:0 4px 24px #0001; }
-.card-body { padding:2rem 1.6rem 1.4rem 1.6rem; }
-.table th, .table td { vertical-align:middle; }
-.table thead { position:sticky; top:0; z-index:2; }
-.table-responsive { max-height:46vh; overflow:auto; }
-#layout { display:flex; height:calc(100vh - 66px); }
-#left { width:22%; min-width:300px; max-width:410px; overflow:auto; padding:1.6rem 1rem 1rem 1.4rem; }
-#right { flex:1; overflow:auto; padding:1.7rem 1.8rem 1.7rem 0.5rem; }
-#drag { width:7px; background:#dee2e6; cursor:col-resize; min-height:90vh; }
-.badge-go   { background:#198754; font-size:.8rem; padding:.36rem .85rem; }
-.badge-wait { background:#ffc107; color:#000; font-size:.8rem; padding:.36rem .85rem; }
-.badge-stop { background:#dc3545; font-size:.8rem; padding:.36rem .85rem; }
-.badge-sell-force { background:#dc3545; font-size:.8rem; padding:.36rem .85rem; }
-.badge-sell-sl    { background:#fd7e14; color:#000; font-size:.8rem; padding:.36rem .85rem; }
-.badge-sell-tp    { background:#0d6efd; font-size:.8rem; padding:.36rem .85rem; }
-.badge-sell-max   { background:#20c997; font-size:.8rem; padding:.36rem .85rem; }
-.badge-sell-wait  { background:#6c757d; font-size:.8rem; padding:.36rem .85rem; }
-::-webkit-scrollbar { width:8px; background:#eaeaea; }
-::-webkit-scrollbar-thumb { background:#d1d7e1; border-radius:5px; }
-.bar-graph, .trend-bar { position:relative; height:16px; background:#e9ecef; border-radius:7px; }
-.bar-graph { width:190px; margin:0 auto; }
-.trend-bar { width:170px; margin:0 auto; }
-.dot { position:absolute; top:50%; transform:translateY(-50%); width:15px; height:15px; border-radius:50%; }
-.dot.stop { background:#dc3545; left:0; }
-.dot.entry { background:#6c757d; }
-.dot.take { background:#0d6efd; right:0; }
-.dot.trend { z-index:2; }
-.dot.green { background:#198754; }
-.dot.red   { background:#dc3545; }
-.dot.yellow{ background:#ffc107; }
-.dot.blue  { background:#0d6efd; }
-.trend-bar .tick { position:absolute; width:2px; height:70%; background:#adb5bd; top:15%; }
-.trend-bar .tick1 { left:33%; }
-.trend-bar .tick2 { right:33%; }
-@media (max-width:1400px) {
-  #left { min-width:200px; }
-  #right { padding:1rem; }
-}
-</style>
 
 <div id="layout">
   <!-- 좌측 -->
@@ -199,7 +153,6 @@ body { background:#f6f8fb; font-size:17px; overflow:hidden; }
 </div><!-- /layout -->
 
 <script>
-document.querySelectorAll('[data-bs-toggle="tooltip"]').forEach(el=>new bootstrap.Tooltip(el));
 const drag = document.getElementById('drag'), left = document.getElementById('left'); let sx, sw;
 drag.addEventListener('mousedown', e => { sx = e.clientX; sw = left.offsetWidth;
   document.addEventListener('mousemove', mv); document.addEventListener('mouseup', up); });

--- a/templates/risk.html
+++ b/templates/risk.html
@@ -1,23 +1,6 @@
 {% extends 'base.html' %}
 {% block title %}Upbit AutoTrading · 리스크 매니지먼트{% endblock %}
 {% block content %}
-<style>
-body{background:#f6f8fb;font-size:18px;}
-.navbar{background:#1e2b45;}
-.card-head{background:#22315a;color:#fff;font-size:1.25rem;padding:1.2rem 2rem;display:flex;align-items:center;gap:.7rem;border-radius:1.25rem 1.25rem 0 0;}
-.card{border-radius:1.25rem;margin-bottom:2.5rem;box-shadow:0 4px 24px #0001;}
-.card-body{padding:2.5rem;}
-label.form-label{font-size:1.08rem;font-weight:600;color:#233;}
-input.form-control,select.form-select{font-size:1.1rem;padding:0.9rem 1.1rem;}
-input[type="number"],input[type="text"]{max-width:220px;}
-.btn-primary{padding:.8rem 2.5rem;font-size:1.15rem;}
-.btn-lg{font-size:1.18rem;}
-.container{max-width:980px;margin-top:56px;}
-.section-label{font-size:1.18rem;font-weight:700;color:#3753a9;margin-bottom:1.2rem;}
-.bi-shield-check,.bi-bell{font-size:2rem;color:#40b4a8;}
-.card-toolbar {display:flex;gap:1.5rem;flex-wrap:wrap;}
-@media (max-width:1100px) {.container{max-width:98vw;}}
-</style>
 
 <div class="container">
 
@@ -123,7 +106,6 @@ input[type="number"],input[type="text"]{max-width:220px;}
   </div>
 </div>
 <script>
-document.querySelectorAll('[data-bs-toggle="tooltip"]').forEach(el=>new bootstrap.Tooltip(el));
 function openLogManager(){ alert('로그 파일 관리/로테이션(서버 API 필요)'); }
 function openAuditHistory(){ alert('감사로그 실시간 조회/다운로드(서버 API 필요)'); }
 function openBackupRestore(){ alert('설정/포지션/로그 백업 및 복구(서버 API 필요)'); }

--- a/templates/settings.html
+++ b/templates/settings.html
@@ -1,21 +1,6 @@
 {% extends 'base.html' %}
 {% block title %}UPBIT AutoTrading · 개인 설정{% endblock %}
 {% block content %}
-<style>
-body{background:#f6f8fb;font-size:18px;}
-.navbar{background:#1e2b45;}
-.card-head{background:#22315a;color:#fff;font-size:1.25rem;padding:1.2rem 2rem;display:flex;align-items:center;gap:.7rem;border-radius:1.25rem 1.25rem 0 0;}
-.card{border-radius:1.25rem;margin-bottom:2.5rem;box-shadow:0 4px 24px #0001;}
-.card-body{padding:2.5rem;}
-label.form-label{font-size:1.08rem;font-weight:600;color:#233;}
-input.form-control,select.form-select{font-size:1.1rem;padding:0.9rem 1.1rem;}
-input[type="password"]{letter-spacing:0.2em;}
-.btn-primary{padding:.8rem 2.5rem;font-size:1.15rem;}
-.container{max-width:740px;margin-top:56px;}
-.section-label{font-size:1.12rem;font-weight:700;color:#3753a9;margin-bottom:1.2rem;}
-.bi-key,.bi-lock,.bi-person-circle,.bi-telegram{font-size:1.6rem;}
-@media (max-width:1200px){.container{max-width:98vw;}}
-</style>
 <div class="container">
   <div class="card shadow-sm mb-5">
     <div class="card-head">
@@ -121,7 +106,5 @@ input[type="password"]{letter-spacing:0.2em;}
     </div>
   </div>
 </div>
-<script>
-document.querySelectorAll('[data-bs-toggle="tooltip"]').forEach(el=>new bootstrap.Tooltip(el));
-</script>
+
 {% endblock %}

--- a/templates/strategy.html
+++ b/templates/strategy.html
@@ -1,23 +1,6 @@
 {% extends 'base.html' %}
 {% block title %}Upbit AutoTrading · 매매 설정{% endblock %}
 {% block content %}
-<style>
-body{background:#f6f8fb;font-size:18px;}
-.navbar{background:#1e2b45;}
-.card-head{background:#22315a;color:#fff;font-size:1.25rem;padding:1.2rem 2rem;display:flex;align-items:center;gap:.7rem;border-radius:1.25rem 1.25rem 0 0;}
-.card{border-radius:1.25rem;margin-bottom:2.5rem;box-shadow:0 4px 24px #0001;}
-.card-body{padding:2.5rem;}
-label.form-label{font-size:1.08rem;font-weight:600;color:#233;}
-input.form-control,select.form-select{font-size:1.1rem;padding:0.9rem 1.1rem;}
-.btn-primary{padding:.8rem 2.5rem;font-size:1.15rem;}
-.container{max-width:1600px;margin-top:56px;}
-.table{background:#fff;}
-.badge-info{background:#edf3ff;color:#1e2b45;font-size:.97rem;font-weight:500;}
-.bi-info-circle{color:#3468e1;}
-th,td{vertical-align:middle;}
-.section-label{font-size:1.22rem;font-weight:700;color:#3753a9;margin-bottom:1.2rem;}
-.form-text{font-size:.99rem;}
-</style>
 
 <div class="container">
 
@@ -251,7 +234,5 @@ th,td{vertical-align:middle;}
     </div>
   </div>
 </div>
-<script>
-document.querySelectorAll('[data-bs-toggle="tooltip"]').forEach(el=>new bootstrap.Tooltip(el));
-</script>
+
 {% endblock %}


### PR DESCRIPTION
## Summary
- remove inline styles from page templates
- centralize styling in `static/css/custom.css`
- rely on `base.html` for Bootstrap JS

## Testing
- `pip install flake8` *(fails: Could not find a version that satisfies the requirement flake8)*