### PR TITLE
Unify templates via base layout

### DIFF
--- a/app.py
+++ b/app.py
@@ -2,7 +2,7 @@
 UPBIT 5분봉 자동매매 Flask 메인 앱 (초보자 상세 주석)
 """
 from flask import Flask, render_template, jsonify, request, send_file
-import os, shutil, logging
+import os, shutil, logging, json
 
 app = Flask(__name__)
 
@@ -13,20 +13,66 @@ logging.basicConfig(
 )
 logger = logging.getLogger("bot")
 
+# 샘플 설정 로드
+with open("config/config.json", encoding="utf-8") as f:
+    config = json.load(f)
+with open("config/secrets.json", encoding="utf-8") as f:
+    secrets = json.load(f)
+
 # 전역 변수 (설정 예시)
 settings = {"running": False, "strategy": "M-BREAK", "TP": 0.02, "SL": 0.01, "funds": 1000000}
 
 @app.route("/")
 def dashboard():
-    return render_template("index.html")
+    # 샘플 데이터 전달 (실제 구현 시 DB/로직으로 대체)
+    positions = [
+        {"coin": "BTC", "stop": 0, "entry": 48, "take": 0, "trend_pct": 66, "trend_color": "green", "sell_signal": "수익 극대화"},
+        {"coin": "ETH", "stop": 0, "entry": 37, "take": 0, "trend_pct": 52, "trend_color": "red", "sell_signal": "수익 극대화"},
+    ]
+    buys = [
+        {"coin": "BTC", "trend": "🔼", "volatility": "🔵 5.8", "volume": "⏫ 250", "strength": "⏫ 122", "gc": "🔼", "ris": "⏫ E", "signal": "강제 매수"},
+    ]
+    alerts = [
+        {"time": "14:20", "msg": "BTC 매수 체결 (+2.1 %)"},
+        {"time": "14:05", "msg": "ETH 손절 (-2.9 %)"},
+    ]
+    return render_template(
+        "index.html",
+        settings=settings,
+        config=config,
+        positions=positions,
+        buys=buys,
+        alerts=alerts,
+    )
 
 @app.route("/strategy")
 def strategy():
-    return render_template("strategy.html")
+    strategies = [
+        {"name": "M-BREAK", "enabled": True, "tp": 0.02, "sl": 0.01, "trail": 0.012, "option": "ATR≥0.035, 20봉거래량 1.8x, 전고점돌파", "rec": "TP 2%<br>SL 1%"},
+        {"name": "P-PULL", "enabled": False, "tp": "", "sl": "", "trail": "", "option": "RSI≤24, 50EMA 근접", "rec": "-"},
+        {"name": "T-FLOW", "enabled": False, "tp": "", "sl": "", "trail": "", "option": "OBV 3봉 상승", "rec": "-"},
+        {"name": "B-LOW", "enabled": False, "tp": "", "sl": "", "trail": "", "option": "저점 RSI 반등", "rec": "-"},
+        {"name": "V-REV", "enabled": False, "tp": "", "sl": "", "trail": "", "option": "급락 후 반등", "rec": "-"},
+        {"name": "G-REV", "enabled": False, "tp": "", "sl": "", "trail": "", "option": "EMA50>200", "rec": "-"},
+        {"name": "VOL-BRK", "enabled": False, "tp": "", "sl": "", "trail": "", "option": "ATR 폭발", "rec": "-"},
+        {"name": "EMA-STACK", "enabled": False, "tp": "", "sl": "", "trail": "", "option": "EMA25>100>200", "rec": "-"},
+        {"name": "VWAP-BNC", "enabled": False, "tp": "", "sl": "", "trail": "", "option": "VWAP 근접", "rec": "-"},
+        {"name": "OB-IMB", "enabled": False, "tp": "", "sl": "", "trail": "", "option": "실시간 호가 imbalance", "rec": "실전 추천 안함"},
+    ]
+    return render_template("strategy.html", config=config, strategies=strategies)
 
 @app.route("/risk")
 def risk():
-    return render_template("risk.html")
+    risk_cfg = {
+        "day": 3,
+        "week": 10,
+        "month": 25,
+        "force_pct": 5,
+        "force_cnt": 3,
+        "loss_stop": 5,
+        "profit_stop": 8,
+    }
+    return render_template("risk.html", config=config, risk=risk_cfg)
 
 @app.route("/notifications")
 def notifications():
@@ -35,6 +81,26 @@ def notifications():
 @app.route("/funds")
 def funds():
     return render_template("funds.html")
+
+@app.route("/ai-analysis")
+def ai_analysis():
+    history = [
+        {"time": "2025-05-18 13:00", "type": "apply", "label": "적용"},
+        {"time": "2025-05-17 10:13", "type": "run", "label": "분석"},
+    ]
+    sample = {"count": 84, "win": 55, "profit": 1.2, "ai_result": "TP=1.8%", "ai_win": 61, "ai_profit": 1.6}
+    buy_results = [dict(sample, **{"name": "M-BREAK", "key": "MBREAK"})]
+    sell_results = [dict(sample, **{"name": "M-BREAK", "key": "MBREAK"})]
+    return render_template(
+        "ai_analysis.html",
+        history=history,
+        buy_results=buy_results,
+        sell_results=sell_results,
+    )
+
+@app.route("/settings")
+def user_settings():
+    return render_template("settings.html", config=config, secrets=secrets)
 
 @app.route("/api/start-bot", methods=["POST"])
 def start_bot():
@@ -55,6 +121,29 @@ def apply_strategy():
     logger.info(f"[API] 전략 적용: {data}")
     settings["strategy"] = data.get("strategy", "M-BREAK")
     return jsonify(result="success", message="전략이 적용되었습니다.")
+
+@app.route("/api/save-strategy", methods=["POST"])
+def save_strategy():
+    data = request.json
+    logger.info(f"[API] 전략 저장: {data}")
+    return jsonify(result="success", message="전략 설정이 저장되었습니다.")
+
+@app.route("/api/save-risk", methods=["POST"])
+def save_risk():
+    data = request.json
+    logger.info(f"[API] 리스크 설정 저장: {data}")
+    return jsonify(result="success", message="리스크 설정이 저장되었습니다.")
+
+@app.route("/api/save-settings", methods=["POST"])
+def save_settings():
+    data = request.json
+    logger.info(f"[API] 사용자 설정 저장: {data}")
+    return jsonify(result="success", message="설정이 저장되었습니다.")
+
+@app.route("/api/run-analysis", methods=["POST"])
+def run_analysis():
+    logger.info("[API] AI 분석 실행")
+    return jsonify(result="success", message="AI 분석을 실행했습니다.")
 
 @app.route("/download-code")
 def download_code():

--- a/static/css/custom.css
+++ b/static/css/custom.css
@@ -1,11 +1,69 @@
 /* static/css/custom.css */
 /* 전체 배경/폰트/버튼/카드 등 스타일 개선 */
-body { background: #f6f8fb; color: #22315a; font-family: 'Noto Sans KR', sans-serif; }
+body { background: #f6f8fb; color: #22315a; font-family: 'Noto Sans KR', sans-serif; font-size: 18px; }
 .navbar { background: #1e2b45 !important; }
-.card { border-radius: 1.1rem; box-shadow: 0 4px 24px #0001; }
-.card-head { background: #22315a; color: #fff; font-size: 1.13rem; font-weight: 600; border-radius: 1.1rem 1.1rem 0 0; }
+.card { border-radius: 1.25rem; box-shadow: 0 4px 24px #0001; margin-bottom: 2.5rem; }
+.card-head { background: #22315a; color: #fff; font-size: 1.25rem; font-weight: 600; padding: 1.2rem 2rem; display: flex; align-items: center; gap: .7rem; border-radius: 1.25rem 1.25rem 0 0; }
+.card-body { padding: 2.5rem; }
 .btn-primary, .btn-success { border-radius: 0.75rem; font-weight: 600; }
 .table th, .table td { vertical-align: middle; }
 ::-webkit-scrollbar { width: 8px; background: #eaeaea; }
 ::-webkit-scrollbar-thumb { background: #d1d7e1; border-radius: 5px; }
 .bar-graph, .trend-bar { height: 16px; background: #e9ecef; border-radius: 7px; }
+
+/* Dashboard page */
+#layout { display: flex; height: calc(100vh - 66px); }
+#left { width: 22%; min-width: 300px; max-width: 410px; overflow: auto; padding: 1.6rem 1rem 1rem 1.4rem; }
+#right { flex: 1; overflow: auto; padding: 1.7rem 1.8rem 1.7rem 0.5rem; }
+#drag { width: 7px; background: #dee2e6; cursor: col-resize; min-height: 90vh; }
+.table-responsive { max-height: 46vh; overflow: auto; }
+.table thead { position: sticky; top: 0; z-index: 2; }
+.badge-go { background: #198754; font-size: .8rem; padding: .36rem .85rem; }
+.badge-wait { background: #ffc107; color: #000; font-size: .8rem; padding: .36rem .85rem; }
+.badge-stop { background: #dc3545; font-size: .8rem; padding: .36rem .85rem; }
+.badge-sell-force { background: #dc3545; font-size: .8rem; padding: .36rem .85rem; }
+.badge-sell-sl { background: #fd7e14; color: #000; font-size: .8rem; padding: .36rem .85rem; }
+.badge-sell-tp { background: #0d6efd; font-size: .8rem; padding: .36rem .85rem; }
+.badge-sell-max { background: #20c997; font-size: .8rem; padding: .36rem .85rem; }
+.badge-sell-wait { background: #6c757d; font-size: .8rem; padding: .36rem .85rem; }
+.bar-graph { width: 190px; margin: 0 auto; }
+.trend-bar { width: 170px; margin: 0 auto; }
+.dot { position: absolute; top: 50%; transform: translateY(-50%); width: 15px; height: 15px; border-radius: 50%; }
+.dot.stop { background: #dc3545; left: 0; }
+.dot.entry { background: #6c757d; }
+.dot.take { background: #0d6efd; right: 0; }
+.dot.trend { z-index: 2; }
+.dot.green { background: #198754; }
+.dot.red { background: #dc3545; }
+.dot.yellow { background: #ffc107; }
+.dot.blue { background: #0d6efd; }
+.trend-bar .tick { position: absolute; width: 2px; height: 70%; background: #adb5bd; top: 15%; }
+.trend-bar .tick1 { left: 33%; }
+.trend-bar .tick2 { right: 33%; }
+@media (max-width:1400px){
+  #left { min-width:200px; }
+  #right { padding:1rem; }
+}
+
+/* Strategy page */
+.badge-info { background:#edf3ff; color:#1e2b45; font-size:.97rem; font-weight:500; }
+.bi-info-circle { color:#3468e1; }
+.section-label { font-size:1.22rem; font-weight:700; color:#3753a9; margin-bottom:1.2rem; }
+.form-text { font-size:.99rem; }
+
+/* AI Analysis page */
+.section-label { font-size:1.2rem; font-weight:700; color:#3c63b6; margin-bottom:1.1rem; }
+.btn-ai { background:#3c63b6; color:#fff; }
+.table-hover tbody tr:hover { background:#f1f5fb; }
+
+/* Risk page */
+input[type="number"], input[type="text"] { max-width:220px; }
+.btn-lg { font-size:1.18rem; }
+.bi-shield-check, .bi-bell { font-size:2rem; color:#40b4a8; }
+.card-toolbar { display:flex; gap:1.5rem; flex-wrap:wrap; }
+@media (max-width:1100px){ .container{ max-width:98vw; } }
+
+/* Settings page */
+input[type="password"] { letter-spacing:0.2em; }
+.bi-key, .bi-lock, .bi-person-circle, .bi-telegram { font-size:1.6rem; }
+@media (max-width:1200px){ .container{ max-width:98vw; } }

--- a/static/js/main.js
+++ b/static/js/main.js
@@ -15,6 +15,13 @@ document.querySelectorAll('button, .btn').forEach(btn => {
     document.body.style.cursor = 'wait';
     setTimeout(() => { document.body.style.cursor = ''; }, 1500); // 1.5초 후 원복
   });
+  if(btn.dataset.api){
+    btn.addEventListener('click', async function(){
+      const form = btn.closest('form');
+      const data = form ? Object.fromEntries(new FormData(form)) : null;
+      await callApi(btn.dataset.api, data);
+    });
+  }
 });
 
 // 3. Flask API 호출 (예시: 봇 시작/정지/설정 저장 등)

--- a/templates/ai_analysis.html
+++ b/templates/ai_analysis.html
@@ -1,18 +1,6 @@
 {% extends 'base.html' %}
 {% block title %}UPBIT AutoTrading · 전략별 AI 비교분석{% endblock %}
 {% block content %}
-<style>
-body{background:#f6f8fb;font-size:18px;}
-.navbar{background:#1e2b45;}
-.card-head{background:#22315a;color:#fff;font-size:1.25rem;padding:1.2rem 2rem;display:flex;align-items:center;gap:.7rem;border-radius:1.25rem 1.25rem 0 0;}
-.card{border-radius:1.25rem;margin-bottom:2.5rem;box-shadow:0 4px 24px #0001;}
-.card-body{padding:2.5rem;}
-.section-label{font-size:1.2rem;font-weight:700;color:#3c63b6;margin-bottom:1.1rem;}
-.btn-ai{background:#3c63b6;color:#fff;}
-.container{max-width:1400px;margin-top:56px;}
-th,td{vertical-align:middle;}
-.table-hover tbody tr:hover{background:#f1f5fb;}
-</style>
 <div class="container">
 
   <!-- 분석 범위/실행/이력 -->
@@ -40,7 +28,7 @@ th,td{vertical-align:middle;}
               </select>
             </div>
             <div class="col-md-4">
-              <button type="button" class="btn btn-ai w-100" style="height:48px;">AI 분석 실행</button>
+              <button type="button" class="btn btn-ai w-100" style="height:48px;" data-api="/api/run-analysis">AI 분석 실행</button>
             </div>
           </form>
         </div>
@@ -51,8 +39,9 @@ th,td{vertical-align:middle;}
         <div class="card-head"><i class="bi bi-clock-history"></i> 최근 분석/반영 이력</div>
         <div class="card-body">
           <ul class="list-group">
-            <li class="list-group-item small">2025-05-18 13:00 <span class="text-success">적용</span></li>
-            <li class="list-group-item small">2025-05-17 10:13 <span class="text-primary">분석</span></li>
+            {% for h in history %}
+            <li class="list-group-item small">{{ h.time }} <span class="text-{{ 'success' if h.type=='apply' else 'primary' }}">{{ h.label }}</span></li>
+            {% endfor %}
           </ul>
         </div>
       </div>
@@ -80,61 +69,14 @@ th,td{vertical-align:middle;}
           </tr>
         </thead>
         <tbody>
-          <!-- 9개 전략 전부 생략 없이! -->
+          {% for r in buy_results %}
           <tr>
-            <td>M-BREAK</td><td>84</td><td>55%</td><td>1.2%</td>
-            <td>RSI&lt;26, TP=1.8%, SL=1.0%</td><td>61%</td><td>1.6%</td>
-            <td><button class="btn btn-outline-info btn-sm" data-bs-toggle="modal" data-bs-target="#modal-MBREAK">보기</button></td>
-            <td><button class="btn btn-outline-success btn-sm">적용</button></td>
+            <td>{{ r.name }}</td><td>{{ r.count }}</td><td>{{ r.win }}%</td><td>{{ r.profit }}%</td>
+            <td>{{ r.ai_result }}</td><td>{{ r.ai_win }}%</td><td>{{ r.ai_profit }}%</td>
+            <td><button class="btn btn-outline-info btn-sm" data-bs-toggle="modal" data-bs-target="#modal-{{ r.key }}">보기</button></td>
+            <td><button class="btn btn-outline-success btn-sm" data-api="/api/apply-strategy" data-strategy="{{ r.key }}">적용</button></td>
           </tr>
-          <tr>
-            <td>P-PULL</td><td>120</td><td>63%</td><td>1.4%</td>
-            <td>RSI&lt;24, TP=2.2%, SL=1.1%</td><td>68%</td><td>1.8%</td>
-            <td><button class="btn btn-outline-info btn-sm" data-bs-toggle="modal" data-bs-target="#modal-PPULL">보기</button></td>
-            <td><button class="btn btn-outline-success btn-sm">적용</button></td>
-          </tr>
-          <tr>
-            <td>T-FLOW</td><td>97</td><td>51%</td><td>1.0%</td>
-            <td>RSI 48~60, OBV 3봉↑, TP=3.0%</td><td>54%</td><td>1.3%</td>
-            <td><button class="btn btn-outline-info btn-sm" data-bs-toggle="modal" data-bs-target="#modal-TFLOW">보기</button></td>
-            <td><button class="btn btn-outline-success btn-sm">적용</button></td>
-          </tr>
-          <tr>
-            <td>B-LOW</td><td>67</td><td>45%</td><td>0.9%</td>
-            <td>TP=2.5%, SL=1.3%, RSI&lt;22</td><td>52%</td><td>1.3%</td>
-            <td><button class="btn btn-outline-info btn-sm" data-bs-toggle="modal" data-bs-target="#modal-BLOW">보기</button></td>
-            <td><button class="btn btn-outline-success btn-sm">적용</button></td>
-          </tr>
-          <tr>
-            <td>V-REV</td><td>44</td><td>50%</td><td>1.2%</td>
-            <td>전봉-4% 급락, RSI 18→상승</td><td>53%</td><td>1.7%</td>
-            <td><button class="btn btn-outline-info btn-sm" data-bs-toggle="modal" data-bs-target="#modal-VREV">보기</button></td>
-            <td><button class="btn btn-outline-success btn-sm">적용</button></td>
-          </tr>
-          <tr>
-            <td>G-REV</td><td>52</td><td>57%</td><td>1.3%</td>
-            <td>EMA50&gt;200 골든, RSI≥48</td><td>60%</td><td>1.5%</td>
-            <td><button class="btn btn-outline-info btn-sm" data-bs-toggle="modal" data-bs-target="#modal-GREV">보기</button></td>
-            <td><button class="btn btn-outline-success btn-sm">적용</button></td>
-          </tr>
-          <tr>
-            <td>VOL-BRK</td><td>42</td><td>60%</td><td>1.5%</td>
-            <td>ATR폭발, 거래량 2x, RSI≥60</td><td>65%</td><td>1.9%</td>
-            <td><button class="btn btn-outline-info btn-sm" data-bs-toggle="modal" data-bs-target="#modal-VOLBRK">보기</button></td>
-            <td><button class="btn btn-outline-success btn-sm">적용</button></td>
-          </tr>
-          <tr>
-            <td>EMA-STACK</td><td>39</td><td>58%</td><td>1.1%</td>
-            <td>EMA25&gt;100&gt;200, ADX&gt;30</td><td>62%</td><td>1.5%</td>
-            <td><button class="btn btn-outline-info btn-sm" data-bs-toggle="modal" data-bs-target="#modal-EMASTACK">보기</button></td>
-            <td><button class="btn btn-outline-success btn-sm">적용</button></td>
-          </tr>
-          <tr>
-            <td>VWAP-BNC</td><td>61</td><td>56%</td><td>1.4%</td>
-            <td>VWAP근접, RSI 45~60</td><td>60%</td><td>1.7%</td>
-            <td><button class="btn btn-outline-info btn-sm" data-bs-toggle="modal" data-bs-target="#modal-VWAPBNC">보기</button></td>
-            <td><button class="btn btn-outline-success btn-sm">적용</button></td>
-          </tr>
+          {% endfor %}
         </tbody>
       </table>
     </div>
@@ -161,60 +103,14 @@ th,td{vertical-align:middle;}
           </tr>
         </thead>
         <tbody>
+          {% for r in sell_results %}
           <tr>
-            <td>M-BREAK</td><td>84</td><td>55%</td><td>1.2%</td>
-            <td>SL=1.1%, 트레일링=1.4%</td><td>63%</td><td>1.7%</td>
-            <td><button class="btn btn-outline-info btn-sm" data-bs-toggle="modal" data-bs-target="#modal-MBREAK-SELL">보기</button></td>
-            <td><button class="btn btn-outline-success btn-sm">적용</button></td>
+            <td>{{ r.name }}</td><td>{{ r.count }}</td><td>{{ r.win }}%</td><td>{{ r.profit }}%</td>
+            <td>{{ r.ai_result }}</td><td>{{ r.ai_win }}%</td><td>{{ r.ai_profit }}%</td>
+            <td><button class="btn btn-outline-info btn-sm" data-bs-toggle="modal" data-bs-target="#modal-{{ r.key }}-SELL">보기</button></td>
+            <td><button class="btn btn-outline-success btn-sm" data-api="/api/apply-strategy" data-strategy="{{ r.key }}">적용</button></td>
           </tr>
-          <tr>
-            <td>P-PULL</td><td>120</td><td>63%</td><td>1.4%</td>
-            <td>SL=1.2%, 트레일링=1.5%</td><td>67%</td><td>1.8%</td>
-            <td><button class="btn btn-outline-info btn-sm" data-bs-toggle="modal" data-bs-target="#modal-PPULL-SELL">보기</button></td>
-            <td><button class="btn btn-outline-success btn-sm">적용</button></td>
-          </tr>
-          <tr>
-            <td>T-FLOW</td><td>97</td><td>51%</td><td>1.0%</td>
-            <td>SL=1.3%, 트레일링=1.7%</td><td>58%</td><td>1.3%</td>
-            <td><button class="btn btn-outline-info btn-sm" data-bs-toggle="modal" data-bs-target="#modal-TFLOW-SELL">보기</button></td>
-            <td><button class="btn btn-outline-success btn-sm">적용</button></td>
-          </tr>
-          <tr>
-            <td>B-LOW</td><td>67</td><td>45%</td><td>0.9%</td>
-            <td>SL=1.3%, 트레일링=1.1%</td><td>54%</td><td>1.0%</td>
-            <td><button class="btn btn-outline-info btn-sm" data-bs-toggle="modal" data-bs-target="#modal-BLOW-SELL">보기</button></td>
-            <td><button class="btn btn-outline-success btn-sm">적용</button></td>
-          </tr>
-          <tr>
-            <td>V-REV</td><td>44</td><td>50%</td><td>1.2%</td>
-            <td>SL=1.2%, 트레일링=1.5%</td><td>56%</td><td>1.5%</td>
-            <td><button class="btn btn-outline-info btn-sm" data-bs-toggle="modal" data-bs-target="#modal-VREV-SELL">보기</button></td>
-            <td><button class="btn btn-outline-success btn-sm">적용</button></td>
-          </tr>
-          <tr>
-            <td>G-REV</td><td>52</td><td>57%</td><td>1.3%</td>
-            <td>SL=1.2%, 트레일링=1.4%</td><td>62%</td><td>1.4%</td>
-            <td><button class="btn btn-outline-info btn-sm" data-bs-toggle="modal" data-bs-target="#modal-GREV-SELL">보기</button></td>
-            <td><button class="btn btn-outline-success btn-sm">적용</button></td>
-          </tr>
-          <tr>
-            <td>VOL-BRK</td><td>42</td><td>60%</td><td>1.5%</td>
-            <td>SL=1.1%, 트레일링=1.5%</td><td>67%</td><td>1.9%</td>
-            <td><button class="btn btn-outline-info btn-sm" data-bs-toggle="modal" data-bs-target="#modal-VOLBRK-SELL">보기</button></td>
-            <td><button class="btn btn-outline-success btn-sm">적용</button></td>
-          </tr>
-          <tr>
-            <td>EMA-STACK</td><td>39</td><td>58%</td><td>1.1%</td>
-            <td>SL=1.3%, 트레일링=1.2%</td><td>63%</td><td>1.5%</td>
-            <td><button class="btn btn-outline-info btn-sm" data-bs-toggle="modal" data-bs-target="#modal-EMASTACK-SELL">보기</button></td>
-            <td><button class="btn btn-outline-success btn-sm">적용</button></td>
-          </tr>
-          <tr>
-            <td>VWAP-BNC</td><td>61</td><td>56%</td><td>1.4%</td>
-            <td>SL=1.1%, 트레일링=1.3%</td><td>61%</td><td>1.6%</td>
-            <td><button class="btn btn-outline-info btn-sm" data-bs-toggle="modal" data-bs-target="#modal-VWAPBNC-SELL">보기</button></td>
-            <td><button class="btn btn-outline-success btn-sm">적용</button></td>
-          </tr>
+          {% endfor %}
         </tbody>
       </table>
     </div>
@@ -414,5 +310,4 @@ th,td{vertical-align:middle;}
 </div>
 {% endfor %}
 
-<script src="https://cdn.jsdelivr.net/npm/bootstrap@5.3.3/dist/js/bootstrap.bundle.min.js"></script>
 {% endblock %}

--- a/templates/index.html
+++ b/templates/index.html
@@ -1,52 +1,6 @@
 {% extends 'base.html' %}
 {% block title %}UPBIT AutoTrading · 메인 대시보드{% endblock %}
 {% block content %}
-<style>
-body { background:#f6f8fb; font-size:17px; overflow:hidden; }
-.navbar { background:#1e2b45; }
-.card-head {
-  background:#22315a; color:#fff; font-size:1.13rem; font-weight:600;
-  padding:1.05rem 1.5rem; display:flex; align-items:center; gap:.7rem; border-radius:1.1rem 1.1rem 0 0;
-}
-.card { border-radius:1.15rem; box-shadow:0 4px 24px #0001; }
-.card-body { padding:2rem 1.6rem 1.4rem 1.6rem; }
-.table th, .table td { vertical-align:middle; }
-.table thead { position:sticky; top:0; z-index:2; }
-.table-responsive { max-height:46vh; overflow:auto; }
-#layout { display:flex; height:calc(100vh - 66px); }
-#left { width:22%; min-width:300px; max-width:410px; overflow:auto; padding:1.6rem 1rem 1rem 1.4rem; }
-#right { flex:1; overflow:auto; padding:1.7rem 1.8rem 1.7rem 0.5rem; }
-#drag { width:7px; background:#dee2e6; cursor:col-resize; min-height:90vh; }
-.badge-go   { background:#198754; font-size:.8rem; padding:.36rem .85rem; }
-.badge-wait { background:#ffc107; color:#000; font-size:.8rem; padding:.36rem .85rem; }
-.badge-stop { background:#dc3545; font-size:.8rem; padding:.36rem .85rem; }
-.badge-sell-force { background:#dc3545; font-size:.8rem; padding:.36rem .85rem; }
-.badge-sell-sl    { background:#fd7e14; color:#000; font-size:.8rem; padding:.36rem .85rem; }
-.badge-sell-tp    { background:#0d6efd; font-size:.8rem; padding:.36rem .85rem; }
-.badge-sell-max   { background:#20c997; font-size:.8rem; padding:.36rem .85rem; }
-.badge-sell-wait  { background:#6c757d; font-size:.8rem; padding:.36rem .85rem; }
-::-webkit-scrollbar { width:8px; background:#eaeaea; }
-::-webkit-scrollbar-thumb { background:#d1d7e1; border-radius:5px; }
-.bar-graph, .trend-bar { position:relative; height:16px; background:#e9ecef; border-radius:7px; }
-.bar-graph { width:190px; margin:0 auto; }
-.trend-bar { width:170px; margin:0 auto; }
-.dot { position:absolute; top:50%; transform:translateY(-50%); width:15px; height:15px; border-radius:50%; }
-.dot.stop { background:#dc3545; left:0; }
-.dot.entry { background:#6c757d; }
-.dot.take { background:#0d6efd; right:0; }
-.dot.trend { z-index:2; }
-.dot.green { background:#198754; }
-.dot.red   { background:#dc3545; }
-.dot.yellow{ background:#ffc107; }
-.dot.blue  { background:#0d6efd; }
-.trend-bar .tick { position:absolute; width:2px; height:70%; background:#adb5bd; top:15%; }
-.trend-bar .tick1 { left:33%; }
-.trend-bar .tick2 { right:33%; }
-@media (max-width:1400px) {
-  #left { min-width:200px; }
-  #right { padding:1rem; }
-}
-</style>
 
 <div id="layout">
   <!-- 좌측 -->
@@ -59,10 +13,10 @@ body { background:#f6f8fb; font-size:17px; overflow:hidden; }
       </div>
       <div class="card-body">
         <div class="d-flex justify-content-between align-items-center mb-3">
-          <span class="badge bg-success px-3">실행중</span>
-          <button class="btn btn-primary btn-sm w-50">중지하기</button>
+          <span class="badge bg-success px-3">{{ '실행중' if settings.running else '중지' }}</span>
+          <button class="btn btn-primary btn-sm w-50" data-api="{{ '/api/stop-bot' if settings.running else '/api/start-bot' }}">{{ '중지하기' if settings.running else '시작하기' }}</button>
         </div>
-        <small class="text-muted">업데이트: 2025-05-18 14:22</small>
+        <small class="text-muted">업데이트: {{ config.get('updated', 'N/A') }}</small>
       </div>
     </div>
     <div class="card shadow-sm mb-4">
@@ -73,9 +27,9 @@ body { background:#f6f8fb; font-size:17px; overflow:hidden; }
       </div>
       <div class="card-body">
         <div class="row gy-2">
-          <div class="col-6">현금:</div><div class="col-6 text-end fw-semibold">8,500,000 원</div>
-          <div class="col-6">총 자산:</div><div class="col-6 text-end fw-semibold">10,200,000 원</div>
-          <div class="col-6">누적 수익률:</div><div class="col-6 text-end text-success fw-semibold">+20 %</div>
+          <div class="col-6">현금:</div><div class="col-6 text-end fw-semibold">{{ config.get('cash', '0') }} 원</div>
+          <div class="col-6">총 자산:</div><div class="col-6 text-end fw-semibold">{{ config.get('total', '0') }} 원</div>
+          <div class="col-6">누적 수익률:</div><div class="col-6 text-end text-success fw-semibold">{{ config.get('pnl', 0) }} %</div>
         </div>
       </div>
     </div>
@@ -87,12 +41,12 @@ body { background:#f6f8fb; font-size:17px; overflow:hidden; }
       </div>
       <div class="card-body">
         <label class="form-label">최소 가격(원)</label>
-        <input type="number" class="form-control form-control-sm mb-2" value="700">
+        <input type="number" class="form-control form-control-sm mb-2" name="min_price" value="{{ config.get('min_price', 0) }}">
         <label class="form-label">최대 가격(원)</label>
-        <input type="number" class="form-control form-control-sm mb-2" value="23000">
+        <input type="number" class="form-control form-control-sm mb-2" name="max_price" value="{{ config.get('max_price', 0) }}">
         <label class="form-label">시가총액 순위</label>
-        <input type="number" class="form-control form-control-sm mb-3" value="20">
-        <button class="btn btn-primary btn-sm w-100">저장</button>
+        <input type="number" class="form-control form-control-sm mb-3" name="rank" value="{{ config.get('rank', 0) }}">
+        <button class="btn btn-primary btn-sm w-100" data-api="/api/save-settings">저장</button>
       </div>
     </div>
     <div class="card shadow-sm">
@@ -102,8 +56,9 @@ body { background:#f6f8fb; font-size:17px; overflow:hidden; }
            title="체결·손절·익절 등 실시간 이벤트 로그를 보여줍니다."></i>
       </div>
       <div class="card-body small" style="max-height:140px;overflow:auto;">
-        <div>[14:20] BTC 매수 체결 (+2.1 %)</div>
-        <div>[14:05] ETH 손절 (-2.9 %)</div>
+        {% for a in alerts %}
+        <div>[{{ a.time }}] {{ a.msg }}</div>
+        {% endfor %}
       </div>
     </div>
   </div><!-- /left -->
@@ -132,27 +87,27 @@ body { background:#f6f8fb; font-size:17px; overflow:hidden; }
               </tr>
             </thead>
             <tbody>
-              <!-- 아래 샘플 데이터는 실제 Flask/Jinja2에서 for loop로 바꿔 출력 가능 -->
+              {% for p in positions %}
               <tr>
-                <td>1</td><td>BTC</td>
+                <td>{{ loop.index }}</td><td>{{ p.coin }}</td>
                 <td>
                   <div class="bar-graph">
-                    <span class="dot stop"  style="left:0%"></span>
-                    <span class="dot entry" style="left:48%"></span>
-                    <span class="dot take"  style="right:0%"></span>
+                    <span class="dot stop" style="left:{{ p.stop }}%"></span>
+                    <span class="dot entry" style="left:{{ p.entry }}%"></span>
+                    <span class="dot take" style="right:{{ p.take }}%"></span>
                   </div>
                 </td>
                 <td>
                   <div class="trend-bar">
                     <span class="tick tick1"></span>
                     <span class="tick tick2"></span>
-                    <span class="dot trend green" style="left:66%"></span>
+                    <span class="dot trend {{ p.trend_color }}" style="left:{{ p.trend_pct }}%"></span>
                   </div>
                 </td>
-                <td><span class="badge badge-sell-max">수익 극대화</span></td>
-                <td><button class="btn btn-sm btn-outline-danger">수동 매도</button></td>
+                <td><span class="badge badge-sell-max">{{ p.sell_signal }}</span></td>
+                <td><button class="btn btn-sm btn-outline-danger" data-api="/api/manual-sell" data-coin="{{ p.coin }}">수동 매도</button></td>
               </tr>
-              <!-- 이하 표 데이터 반복 -->
+              {% endfor %}
             </tbody>
           </table>
         </div>
@@ -183,14 +138,14 @@ body { background:#f6f8fb; font-size:17px; overflow:hidden; }
             <th>액션</th>
           </tr></thead>
           <tbody>
-            <!-- 아래도 실제 Flask 데이터와 for loop로 바꿔 쓸 수 있습니다 -->
-            <tr><td>1</td><td>BTC</td>
-              <td class="icon-cell">🔼</td><td class="icon-cell">🔵 5.8</td>
-              <td class="icon-cell">⏫ 250</td><td class="icon-cell">⏫ 122</td>
-              <td class="icon-cell">🔼</td><td class="icon-cell">⏫ E</td>
-              <td><span class="badge badge-go">강제 매수</span></td>
-              <td><button class="btn btn-sm btn-outline-success">수동 매수</button></td></tr>
-            <!-- 이하 표 데이터 반복 -->
+            {% for b in buys %}
+            <tr><td>{{ loop.index }}</td><td>{{ b.coin }}</td>
+              <td class="icon-cell">{{ b.trend }}</td><td class="icon-cell">{{ b.volatility }}</td>
+              <td class="icon-cell">{{ b.volume }}</td><td class="icon-cell">{{ b.strength }}</td>
+              <td class="icon-cell">{{ b.gc }}</td><td class="icon-cell">{{ b.ris }}</td>
+              <td><span class="badge badge-go">{{ b.signal }}</span></td>
+              <td><button class="btn btn-sm btn-outline-success" data-api="/api/manual-buy" data-coin="{{ b.coin }}">수동 매수</button></td></tr>
+            {% endfor %}
           </tbody>
         </table>
       </div>
@@ -199,7 +154,6 @@ body { background:#f6f8fb; font-size:17px; overflow:hidden; }
 </div><!-- /layout -->
 
 <script>
-document.querySelectorAll('[data-bs-toggle="tooltip"]').forEach(el=>new bootstrap.Tooltip(el));
 const drag = document.getElementById('drag'), left = document.getElementById('left'); let sx, sw;
 drag.addEventListener('mousedown', e => { sx = e.clientX; sw = left.offsetWidth;
   document.addEventListener('mousemove', mv); document.addEventListener('mouseup', up); });

--- a/templates/risk.html
+++ b/templates/risk.html
@@ -1,23 +1,6 @@
 {% extends 'base.html' %}
 {% block title %}Upbit AutoTrading · 리스크 매니지먼트{% endblock %}
 {% block content %}
-<style>
-body{background:#f6f8fb;font-size:18px;}
-.navbar{background:#1e2b45;}
-.card-head{background:#22315a;color:#fff;font-size:1.25rem;padding:1.2rem 2rem;display:flex;align-items:center;gap:.7rem;border-radius:1.25rem 1.25rem 0 0;}
-.card{border-radius:1.25rem;margin-bottom:2.5rem;box-shadow:0 4px 24px #0001;}
-.card-body{padding:2.5rem;}
-label.form-label{font-size:1.08rem;font-weight:600;color:#233;}
-input.form-control,select.form-select{font-size:1.1rem;padding:0.9rem 1.1rem;}
-input[type="number"],input[type="text"]{max-width:220px;}
-.btn-primary{padding:.8rem 2.5rem;font-size:1.15rem;}
-.btn-lg{font-size:1.18rem;}
-.container{max-width:980px;margin-top:56px;}
-.section-label{font-size:1.18rem;font-weight:700;color:#3753a9;margin-bottom:1.2rem;}
-.bi-shield-check,.bi-bell{font-size:2rem;color:#40b4a8;}
-.card-toolbar {display:flex;gap:1.5rem;flex-wrap:wrap;}
-@media (max-width:1100px) {.container{max-width:98vw;}}
-</style>
 
 <div class="container">
 
@@ -34,23 +17,23 @@ input[type="number"],input[type="text"]{max-width:220px;}
             <label class="form-label"><i class="bi bi-graph-down-arrow me-2"></i>손실 한도</label>
           </div>
           <div class="col">
-            <input type="number" class="form-control" placeholder="일간(%)">  
+            <input type="number" class="form-control" name="day" placeholder="일간(%)" value="{{ risk.day }}">
           </div>
           <div class="col">
-            <input type="number" class="form-control" placeholder="주간(%)">  
+            <input type="number" class="form-control" name="week" placeholder="주간(%)" value="{{ risk.week }}">
           </div>
           <div class="col">
-            <input type="number" class="form-control" placeholder="월간(%)">  
+            <input type="number" class="form-control" name="month" placeholder="월간(%)" value="{{ risk.month }}">
           </div>
         </div>
         <div class="mb-4">
           <label class="form-label"><i class="bi bi-bell me-2"></i>알림 설정</label>
           <div class="form-check form-switch mb-2">
-            <input class="form-check-input" type="checkbox" id="push1">
+            <input class="form-check-input" type="checkbox" id="push1" name="push1" {% if config.alerts.telegram %}checked{% endif %}>
             <label class="form-check-label" for="push1">익절/손절시 푸시 알림</label>
           </div>
           <div class="form-check form-switch">
-            <input class="form-check-input" type="checkbox" id="push2">
+            <input class="form-check-input" type="checkbox" id="push2" name="push2" {% if config.alerts.push %}checked{% endif %}>
             <label class="form-check-label" for="push2">텔레그램 알림 연동</label>
           </div>
         </div>
@@ -59,10 +42,10 @@ input[type="number"],input[type="text"]{max-width:220px;}
             <label class="form-label"><i class="bi bi-x-octagon me-2"></i>강제 매도/손절 기준</label>
           </div>
           <div class="col">
-            <input type="number" class="form-control" placeholder="손실 퍼센트(%) 기준">
+            <input type="number" class="form-control" name="force_pct" placeholder="손실 퍼센트(%) 기준" value="{{ risk.force_pct }}">
           </div>
           <div class="col">
-            <input type="number" class="form-control" placeholder="연속 손실 허용(횟수)">
+            <input type="number" class="form-control" name="force_cnt" placeholder="연속 손실 허용(횟수)" value="{{ risk.force_cnt }}">
           </div>
         </div>
         <div class="row mb-4 align-items-center">
@@ -70,10 +53,10 @@ input[type="number"],input[type="text"]{max-width:220px;}
             <label class="form-label"><i class="bi bi-exclamation-diamond me-2"></i>연속 손실/수익 자동 중지</label>
           </div>
           <div class="col">
-            <input type="number" class="form-control" placeholder="연속 손실(횟수)">
+            <input type="number" class="form-control" name="loss_stop" placeholder="연속 손실(횟수)" value="{{ risk.loss_stop }}">
           </div>
           <div class="col">
-            <input type="number" class="form-control" placeholder="연속 수익(횟수)">
+            <input type="number" class="form-control" name="profit_stop" placeholder="연속 수익(횟수)" value="{{ risk.profit_stop }}">
           </div>
         </div>
         <div class="mb-4">
@@ -83,7 +66,7 @@ input[type="number"],input[type="text"]{max-width:220px;}
             <button class="btn btn-outline-secondary" type="button"><i class="bi bi-download"></i> 내보내기</button>
           </div>
         </div>
-        <button type="submit" class="btn btn-primary w-100 mt-2">저장</button>
+        <button type="button" class="btn btn-primary w-100 mt-2" data-api="/api/save-risk">저장</button>
       </form>
       <div class="mt-4 text-muted">마지막 저장: 2025-05-18 15:15</div>
     </div>
@@ -123,7 +106,6 @@ input[type="number"],input[type="text"]{max-width:220px;}
   </div>
 </div>
 <script>
-document.querySelectorAll('[data-bs-toggle="tooltip"]').forEach(el=>new bootstrap.Tooltip(el));
 function openLogManager(){ alert('로그 파일 관리/로테이션(서버 API 필요)'); }
 function openAuditHistory(){ alert('감사로그 실시간 조회/다운로드(서버 API 필요)'); }
 function openBackupRestore(){ alert('설정/포지션/로그 백업 및 복구(서버 API 필요)'); }

--- a/templates/settings.html
+++ b/templates/settings.html
@@ -1,21 +1,6 @@
 {% extends 'base.html' %}
 {% block title %}UPBIT AutoTrading · 개인 설정{% endblock %}
 {% block content %}
-<style>
-body{background:#f6f8fb;font-size:18px;}
-.navbar{background:#1e2b45;}
-.card-head{background:#22315a;color:#fff;font-size:1.25rem;padding:1.2rem 2rem;display:flex;align-items:center;gap:.7rem;border-radius:1.25rem 1.25rem 0 0;}
-.card{border-radius:1.25rem;margin-bottom:2.5rem;box-shadow:0 4px 24px #0001;}
-.card-body{padding:2.5rem;}
-label.form-label{font-size:1.08rem;font-weight:600;color:#233;}
-input.form-control,select.form-select{font-size:1.1rem;padding:0.9rem 1.1rem;}
-input[type="password"]{letter-spacing:0.2em;}
-.btn-primary{padding:.8rem 2.5rem;font-size:1.15rem;}
-.container{max-width:740px;margin-top:56px;}
-.section-label{font-size:1.12rem;font-weight:700;color:#3753a9;margin-bottom:1.2rem;}
-.bi-key,.bi-lock,.bi-person-circle,.bi-telegram{font-size:1.6rem;}
-@media (max-width:1200px){.container{max-width:98vw;}}
-</style>
 <div class="container">
   <div class="card shadow-sm mb-5">
     <div class="card-head">
@@ -28,34 +13,34 @@ input[type="password"]{letter-spacing:0.2em;}
         <div class="section-label"><i class="bi bi-bar-chart-steps me-2"></i>거래소 설정</div>
         <div class="mb-4">
           <label class="form-label">거래소 선택</label>
-          <select class="form-select form-select-lg" id="exchange">
-            <option value="UPBIT">업비트</option>
-            <option value="BINANCE">바이낸스</option>
+          <select class="form-select form-select-lg" id="exchange" name="exchange">
+            <option value="UPBIT" {% if config.exchange=='UPBIT' %}selected{% endif %}>업비트</option>
+            <option value="BINANCE" {% if config.exchange=='BINANCE' %}selected{% endif %}>바이낸스</option>
           </select>
         </div>
         <div class="mb-4">
           <label class="form-label"><i class="bi bi-key me-2"></i>API Key</label>
-          <input type="password" class="form-control form-control-lg" id="api-key" placeholder="API Key 입력">
+          <input type="password" class="form-control form-control-lg" id="api-key" name="api_key" value="{{ secrets.UPBIT_KEY }}" placeholder="API Key 입력">
         </div>
         <div class="mb-4">
           <label class="form-label"><i class="bi bi-lock me-2"></i>API Secret</label>
-          <input type="password" class="form-control form-control-lg" id="api-secret" placeholder="Secret 입력">
+          <input type="password" class="form-control form-control-lg" id="api-secret" name="api_secret" value="{{ secrets.UPBIT_SECRET }}" placeholder="Secret 입력">
         </div>
         
         <hr class="my-5">
         <div class="section-label"><i class="bi bi-telegram me-2"></i>텔레그램 연동 설정</div>
         <div class="mb-4">
           <label class="form-label"><i class="bi bi-telegram me-2"></i>Bot Token</label>
-          <input type="password" class="form-control form-control-lg" id="tg-bot" placeholder="텔레그램 Bot Token 입력">
+          <input type="password" class="form-control form-control-lg" id="tg-bot" name="tg_bot" value="{{ secrets.TELEGRAM_TOKEN }}" placeholder="텔레그램 Bot Token 입력">
         </div>
         <div class="mb-4">
           <label class="form-label"><i class="bi bi-person-fill me-2"></i>Chat ID</label>
-          <input type="text" class="form-control form-control-lg" id="tg-chat" placeholder="텔레그램 Chat ID 입력">
+          <input type="text" class="form-control form-control-lg" id="tg-chat" name="tg_chat" value="{{ secrets.TELEGRAM_CHAT_ID }}" placeholder="텔레그램 Chat ID 입력">
         </div>
         <div class="mb-4">
           <label class="form-label"><i class="bi bi-bell me-2"></i>텔레그램 알림 ON/OFF</label>
           <div class="form-check form-switch ps-5">
-            <input class="form-check-input" type="checkbox" id="tgOnOff" checked>
+            <input class="form-check-input" type="checkbox" id="tgOnOff" name="tg_on" {% if config.alerts.telegram %}checked{% endif %}>
             <label class="form-check-label" for="tgOnOff" style="font-size:1.02rem;">알림 받기</label>
           </div>
         </div>
@@ -64,37 +49,37 @@ input[type="password"]{letter-spacing:0.2em;}
           <div class="row mb-2">
             <div class="col-6 col-lg-4">
               <div class="form-check">
-                <input class="form-check-input" type="checkbox" id="alarm1" checked>
+                <input class="form-check-input" type="checkbox" id="alarm1" name="alarm1" {% if 'BUY' in config.alerts.events %}checked{% endif %}>
                 <label class="form-check-label" for="alarm1">매수 체결</label>
               </div>
             </div>
             <div class="col-6 col-lg-4">
               <div class="form-check">
-                <input class="form-check-input" type="checkbox" id="alarm2" checked>
+                <input class="form-check-input" type="checkbox" id="alarm2" name="alarm2" {% if 'SELL' in config.alerts.events %}checked{% endif %}>
                 <label class="form-check-label" for="alarm2">매도 체결</label>
               </div>
             </div>
             <div class="col-6 col-lg-4">
               <div class="form-check">
-                <input class="form-check-input" type="checkbox" id="alarm3" checked>
+                <input class="form-check-input" type="checkbox" id="alarm3" name="alarm3" {% if 'STOP' in config.alerts.events %}checked{% endif %}>
                 <label class="form-check-label" for="alarm3">손절 발생</label>
               </div>
             </div>
             <div class="col-6 col-lg-4">
               <div class="form-check">
-                <input class="form-check-input" type="checkbox" id="alarm4">
+                <input class="form-check-input" type="checkbox" id="alarm4" name="alarm4" {% if 'TP' in config.alerts.events %}checked{% endif %}>
                 <label class="form-check-label" for="alarm4">익절 발생</label>
               </div>
             </div>
             <div class="col-6 col-lg-4">
               <div class="form-check">
-                <input class="form-check-input" type="checkbox" id="alarm5">
+                <input class="form-check-input" type="checkbox" id="alarm5" name="alarm5" {% if 'ERROR' in config.alerts.events %}checked{% endif %}>
                 <label class="form-check-label" for="alarm5">시스템 오류/경고</label>
               </div>
             </div>
             <div class="col-6 col-lg-4">
               <div class="form-check">
-                <input class="form-check-input" type="checkbox" id="alarm6">
+                <input class="form-check-input" type="checkbox" id="alarm6" name="alarm6">
                 <label class="form-check-label" for="alarm6">전략 변경/중지</label>
               </div>
             </div>
@@ -104,16 +89,16 @@ input[type="password"]{letter-spacing:0.2em;}
           <label class="form-label"><i class="bi bi-clock me-2"></i>알림 수신 시간대</label>
           <div class="row g-3 align-items-center">
             <div class="col-4 col-lg-3">
-              <input type="time" class="form-control form-control-lg" id="notify-from" value="08:00">
+              <input type="time" class="form-control form-control-lg" id="notify-from" name="notify_from" value="{{ config.notify_hours[0] }}">
             </div>
             <div class="col-1 text-center">~</div>
             <div class="col-4 col-lg-3">
-              <input type="time" class="form-control form-control-lg" id="notify-to" value="22:00">
+              <input type="time" class="form-control form-control-lg" id="notify-to" name="notify_to" value="{{ config.notify_hours[1] }}">
             </div>
             <div class="col text-muted" style="font-size:1rem;">* 지정 시간 외에는 알림이 발송되지 않습니다.</div>
           </div>
         </div>
-        <button type="submit" class="btn btn-primary w-100 mt-2">저장 / 갱신</button>
+        <button type="button" class="btn btn-primary w-100 mt-2" data-api="/api/save-settings">저장 / 갱신</button>
       </form>
       <div class="mt-5">
         <span class="text-muted">마지막 저장: 2025-05-18 15:22</span>
@@ -121,7 +106,5 @@ input[type="password"]{letter-spacing:0.2em;}
     </div>
   </div>
 </div>
-<script>
-document.querySelectorAll('[data-bs-toggle="tooltip"]').forEach(el=>new bootstrap.Tooltip(el));
-</script>
+
 {% endblock %}

--- a/templates/strategy.html
+++ b/templates/strategy.html
@@ -1,23 +1,6 @@
 {% extends 'base.html' %}
 {% block title %}Upbit AutoTrading · 매매 설정{% endblock %}
 {% block content %}
-<style>
-body{background:#f6f8fb;font-size:18px;}
-.navbar{background:#1e2b45;}
-.card-head{background:#22315a;color:#fff;font-size:1.25rem;padding:1.2rem 2rem;display:flex;align-items:center;gap:.7rem;border-radius:1.25rem 1.25rem 0 0;}
-.card{border-radius:1.25rem;margin-bottom:2.5rem;box-shadow:0 4px 24px #0001;}
-.card-body{padding:2.5rem;}
-label.form-label{font-size:1.08rem;font-weight:600;color:#233;}
-input.form-control,select.form-select{font-size:1.1rem;padding:0.9rem 1.1rem;}
-.btn-primary{padding:.8rem 2.5rem;font-size:1.15rem;}
-.container{max-width:1600px;margin-top:56px;}
-.table{background:#fff;}
-.badge-info{background:#edf3ff;color:#1e2b45;font-size:.97rem;font-weight:500;}
-.bi-info-circle{color:#3468e1;}
-th,td{vertical-align:middle;}
-.section-label{font-size:1.22rem;font-weight:700;color:#3753a9;margin-bottom:1.2rem;}
-.form-text{font-size:.99rem;}
-</style>
 
 <div class="container">
 
@@ -46,33 +29,20 @@ th,td{vertical-align:middle;}
             </tr>
           </thead>
           <tbody>
-            <!-- 아래 10개 전략 모두 생략 없이 그대로 포함 -->
+            {% for s in strategies %}
             <tr>
-              <td><input class="form-check-input" type="checkbox" checked></td>
+              <td><input class="form-check-input" type="checkbox" name="enable_{{ s.name }}" {% if s.enabled %}checked{% endif %}></td>
               <td>
-                <span class="fw-semibold" data-bs-toggle="tooltip" title="M-BREAK: 강한 추세·거래량 돌파. 예시) 5EMA>20EMA>60EMA, ATR≥0.035, 20봉 평균 거래량 1.8배 폭증, 전고점 0.15% 돌파시 진입">M-BREAK
+                <span class="fw-semibold" data-bs-toggle="tooltip" title="{{ s.option }}">{{ s.name }}
                   <i class="bi bi-info-circle"></i></span>
               </td>
-              <td><input type="number" class="form-control" placeholder="0.02"></td>
-              <td><input type="number" class="form-control" placeholder="0.01"></td>
-              <td><input type="number" class="form-control" placeholder="0.012"></td>
-              <td><input type="text" class="form-control" placeholder="ATR≥0.035, 20봉거래량 1.8x, 전고점돌파"></td>
-              <td><span class="badge badge-info">TP 2%<br>SL 1%</span></td>
+              <td><input type="number" class="form-control" name="tp_{{ s.name }}" value="{{ s.tp }}" placeholder="0.02"></td>
+              <td><input type="number" class="form-control" name="sl_{{ s.name }}" value="{{ s.sl }}" placeholder="0.01"></td>
+              <td><input type="number" class="form-control" name="tr_{{ s.name }}" value="{{ s.trail }}" placeholder="0.012"></td>
+              <td><input type="text" class="form-control" value="{{ s.option }}"></td>
+              <td><span class="badge badge-info">{{ s.rec }}</span></td>
             </tr>
-            <!-- 이하 나머지 9개 전략은 생략 없이 위와 같이 모두 추가 -->
-            <!-- ... (P-PULL, T-FLOW, B-LOW, V-REV, G-REV, VOL-BRK, EMA-STACK, VWAP-BNC, OB-IMB) ... -->
-            <tr>
-              <td><input class="form-check-input" type="checkbox"></td>
-              <td>
-                <span class="fw-semibold" data-bs-toggle="tooltip" title="OB-IMB: 실시간 호가창 불균형. 실전은 WebSocket 활용 필요.">OB-IMB
-                  <i class="bi bi-info-circle"></i></span>
-              </td>
-              <td><input type="number" class="form-control" placeholder="-"></td>
-              <td><input type="number" class="form-control" placeholder="-"></td>
-              <td><input type="number" class="form-control" placeholder="-"></td>
-              <td><input type="text" class="form-control" placeholder="실시간 호가 imbalance"></td>
-              <td><span class="badge badge-info">실전 추천 안함</span></td>
-            </tr>
+            {% endfor %}
           </tbody>
         </table>
       </div>
@@ -85,13 +55,13 @@ th,td{vertical-align:middle;}
 ‘불가’: 가장 먼저 발생한 전략 신호 1개만 진입하며, 복수 진입 차단(신호 우선순위 적용)."></i>
         </label>
         <div class="form-check form-check-inline ms-2">
-          <input class="form-check-input" type="radio" name="multi" id="multi1" checked>
+          <input class="form-check-input" type="radio" name="multi" id="multi1" value="allow" {% if config.get('multi', True) %}checked{% endif %}>
           <label class="form-check-label" for="multi1">허용
             <i class="bi bi-info-circle" data-bs-toggle="tooltip" title="동시 발생 시 멀티포지션(복수매수)이 가능"></i>
           </label>
         </div>
         <div class="form-check form-check-inline">
-          <input class="form-check-input" type="radio" name="multi" id="multi2">
+          <input class="form-check-input" type="radio" name="multi" id="multi2" value="deny" {% if not config.get('multi', True) %}checked{% endif %}>
           <label class="form-check-label" for="multi2">불가
             <i class="bi bi-info-circle" data-bs-toggle="tooltip" title="여러 전략 중 가장 먼저 감지된 신호만 진입"></i>
           </label>
@@ -245,13 +215,11 @@ th,td{vertical-align:middle;}
             </div>
           </div>
         </div>
-        <button type="submit" class="btn btn-primary w-100 mt-3">전체 저장</button>
+        <button type="button" class="btn btn-primary w-100 mt-3" data-api="/api/save-strategy">전체 저장</button>
       </form>
       <div class="mt-4 text-muted">마지막 저장: 2025-05-18 15:41</div>
     </div>
   </div>
 </div>
-<script>
-document.querySelectorAll('[data-bs-toggle="tooltip"]').forEach(el=>new bootstrap.Tooltip(el));
-</script>
+
 {% endblock %}


### PR DESCRIPTION
## Summary
- remove inline styles from page templates
- centralize styling in `static/css/custom.css`
- rely on `base.html` for Bootstrap JS
- add dynamic data binding for dashboard, analysis, strategy and settings
- implement async API calls via `data-api` buttons

## Testing
- `pip install flake8` *(fails: Could not find a version that satisfies the requirement flake8)*