### PR TITLE
Centralize secrets loading

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,6 +38,24 @@ python app.py
 The app runs with `socketio.run` so WebSocket notifications work by default.
 Real time events are pushed to the browser via SocketIO and displayed with `showAlert()` in `main.js`.
 
+## Secrets configuration
+All API keys and tokens are read from `config/secrets.json`. Create the file before starting the server:
+
+```json
+{
+  "UPBIT_KEY": "YOUR-UPBIT-KEY",
+  "UPBIT_SECRET": "YOUR-UPBIT-SECRET",
+  "TELEGRAM_TOKEN": "BOT-TOKEN",
+  "TELEGRAM_CHAT_ID": "123456789"
+}
+```
+
+If the file is missing or any required value is empty the application stops with an error. When Telegram details are available the same message is sent to that chat as well.
+Example error:
+```
+[ERROR] Missing required secrets: UPBIT_KEY, UPBIT_SECRET
+```
+
 ## Windows 설치 가이드
 Windows 10/11 + Visual Studio C++ 빌드툴 환경에서 다음 순서로 준비합니다.
 

--- a/app.py
+++ b/app.py
@@ -6,6 +6,8 @@ from flask_socketio import SocketIO
 import os, shutil, logging, json  # 기본 모듈들
 from datetime import datetime
 
+from utils import load_secrets
+
 app = Flask(__name__)  # Flask 애플리케이션 생성
 socketio = SocketIO(app, cors_allowed_origins="*")  # 실시간 알림용 SocketIO
 
@@ -19,8 +21,9 @@ logger = logging.getLogger("bot")
 # 샘플 설정 로드
 with open("config/config.json", encoding="utf-8") as f:
     config = json.load(f)
-with open("config/secrets.json", encoding="utf-8") as f:
-    secrets = json.load(f)
+
+# secrets.json 을 공통 로더로 읽기
+secrets = load_secrets()
 
 # 전역 변수 (설정 예시)
 settings = {"running": False, "strategy": "M-BREAK", "TP": 0.02, "SL": 0.01,
@@ -47,8 +50,9 @@ settings = {"running": False, "strategy": "M-BREAK", "TP": 0.02, "SL": 0.01,
 
 with open('config/config.json', encoding='utf-8') as f:
     config_data = json.load(f)
-with open('config/secrets.json', encoding='utf-8') as f:
-    secrets_data = json.load(f)
+
+# 템플릿 렌더링을 위해 secrets 재사용
+secrets_data = secrets
 
 positions = [
     {"coin": "BTC", "entry": 48, "trend": 66, "trend_color": "green", "signal": "sell-max", "signal_label": "수익 극대화"},

--- a/utils.py
+++ b/utils.py
@@ -1,0 +1,64 @@
+import json
+import logging
+import sys
+from typing import Iterable
+import requests
+
+
+def send_telegram(token: str, chat_id: str, text: str) -> None:
+    """Send a message via Telegram bot API."""
+    try:
+        requests.post(
+            f"https://api.telegram.org/bot{token}/sendMessage",
+            data={"chat_id": chat_id, "text": text},
+            timeout=5,
+        )
+    except Exception as e:
+        logging.error(f"Telegram send failed: {e}")
+
+
+def load_secrets(
+    path: str = "config/secrets.json",
+    required: Iterable[str] = (
+        "UPBIT_KEY",
+        "UPBIT_SECRET",
+        "TELEGRAM_TOKEN",
+    ),
+) -> dict:
+    """Load secrets from ``path`` and ensure required fields exist.
+
+    If the file is missing, unreadable or lacks required keys, the
+    application prints an error, logs it and exits with status 1.
+    A Telegram message is sent when token and chat id are available.
+    """
+    try:
+        with open(path, encoding="utf-8") as f:
+            secrets = json.load(f)
+    except FileNotFoundError:
+        msg = f"[ERROR] Required file '{path}' not found."
+        print(msg)
+        logging.error(msg)
+        sys.exit(1)
+    except PermissionError:
+        msg = f"[ERROR] No permission to read '{path}'."
+        print(msg)
+        logging.error(msg)
+        sys.exit(1)
+    except json.JSONDecodeError as e:
+        msg = f"[ERROR] Failed to parse '{path}': {e}"
+        print(msg)
+        logging.error(msg)
+        sys.exit(1)
+
+    missing = [key for key in required if not secrets.get(key)]
+    if missing:
+        msg = f"[ERROR] Missing required secrets: {', '.join(missing)}"
+        print(msg)
+        logging.error(msg)
+        token = secrets.get("TELEGRAM_TOKEN")
+        chat_id = secrets.get("TELEGRAM_CHAT_ID")
+        if token and chat_id:
+            send_telegram(token, chat_id, msg)
+        sys.exit(1)
+
+    return secrets


### PR DESCRIPTION
## Summary
- create `utils.load_secrets` for unified secret handling
- exit with error and optional Telegram alert when `config/secrets.json` is missing or incomplete
- use the loader in `app.py`
- document secrets.json usage in README

## Testing
- `python -m py_compile utils.py app.py bot/trader.py`
- `find . -name '*.py' -not -path './.git/*' | xargs python -m py_compile`