### PR TITLE
Enhance dashboard UI and balance monitoring

### DIFF
--- a/app.py
+++ b/app.py
@@ -670,8 +670,15 @@ def manual_buy():
             raise ValueError("Invalid coin")
         socketio.emit('notification', {'message': f'{coin} 수동 매수 요청'})
         global positions, alerts
-        positions.append({"coin": coin, "entry": 50, "trend": 50, "trend_color": "green",
-                          "signal": "sell-wait", "signal_label": "관망"})
+        positions.append({
+            "coin": coin,
+            "pnl": 0,
+            "entry": 50,
+            "trend": 50,
+            "trend_color": "green",
+            "signal": "sell-wait",
+            "signal_label": "관망",
+        })
         alerts.insert(0, {"time": datetime.now().strftime('%H:%M'), "message": f"{coin} 매수"})
         socketio.emit('positions', positions)
         socketio.emit('alerts', alerts)

--- a/bot/trader.py
+++ b/bot/trader.py
@@ -162,8 +162,17 @@ class UpbitTrader:
             bal = float(b.get("balance", 0))
             if currency == "KRW" or bal == 0:
                 continue
+            try:
+                price = pyupbit.get_current_price(f"KRW-{currency}") or 0
+            except Exception:
+                if self.logger:
+                    self.logger.warning("Price lookup failed for %s", currency)
+                price = 0
+            avg_buy = float(b.get("avg_buy_price", 0))
+            pnl = round((price - avg_buy) / avg_buy * 100, 2) if avg_buy else 0.0
             positions.append({
                 "coin": currency,
+                "pnl": pnl,
                 "entry": 50,
                 "trend": 50,
                 "trend_color": "green",

--- a/static/css/custom.css
+++ b/static/css/custom.css
@@ -89,3 +89,12 @@ input[type="password"] { letter-spacing:0.2em; }
 /* Reload icon */
 .reload-btn { cursor:pointer; color:#fff; transition:transform .2s; }
 .reload-btn:hover { color:#0d6efd; transform:rotate(90deg); }
+
+/* Coin filter form inline layout */
+#coinFilterForm .form-group .form-label {
+  width: 120px;
+}
+#coinFilterForm .form-group .form-control {
+  flex: 1;
+  max-width: 160px;
+}

--- a/static/js/main.js
+++ b/static/js/main.js
@@ -234,9 +234,10 @@ async function reloadBalance(){
 function updateBalanceTable(list){
   const body = document.getElementById('positionBody');
   if(!body) return;
-  body.innerHTML = list.map((p, i) => `
+  body.innerHTML = list.map(p => `
     <tr>
-      <td>${i+1}</td><td>${p.coin}</td>
+      <td>${p.coin}</td>
+      <td>${p.pnl} %</td>
       <td>
         <div class="bar-graph">
           <span class="dot stop"></span>
@@ -338,5 +339,7 @@ async function reloadAccount(){
 
 document.addEventListener('DOMContentLoaded', ()=>{
   setInterval(reloadAccount, 10000);
+  setInterval(reloadBalance, 5000);
   reloadAccount();
+  reloadBalance();
 });

--- a/templates/index.html
+++ b/templates/index.html
@@ -13,11 +13,14 @@
       </div>
       <div class="card-body">
         <div class="d-flex justify-content-between align-items-center mb-3">
-          <span class="badge {% if running %}bg-success{% else %}bg-secondary{% endif %} px-3" id="bot-status">
-            {% if running %}실행중{% else %}정지{% endif %}
-          </span>
-          <button class="btn {% if running %}btn-danger{% else %}btn-primary{% endif %} btn-sm w-50" data-api="{{ '/api/stop-bot' if running else '/api/start-bot' }}">
-            {% if running %}중지하기{% else %}시작하기{% endif %}
+          <div>
+            <span class="me-2">현재 상태:</span>
+            <span class="badge {% if running %}bg-success{% else %}bg-secondary{% endif %} px-3" id="bot-status">
+              {% if running %}실행중{% else %}정지{% endif %}
+            </span>
+          </div>
+          <button class="btn {% if running %}btn-danger{% else %}btn-primary{% endif %} btn-sm min-w-140" data-api="{{ '/api/stop-bot' if running else '/api/start-bot' }}">
+            {% if running %}봇 중지{% else %}봇 시작{% endif %}
           </button>
         </div>
         <small class="text-muted" id="updateTime">업데이트: {{ updated }}</small>
@@ -45,16 +48,16 @@
       </div>
       <div class="card-body">
         <form id="coinFilterForm">
-          <div class="mb-2">
-            <label class="form-label">최소 가격(원)</label>
+          <div class="form-group d-flex align-items-center mb-2">
+            <label class="form-label me-2 mb-0">최소 가격(원)</label>
             <input type="number" class="form-control form-control-sm" name="min_price" value="{{ config.get('min_price', 0) }}">
           </div>
-          <div class="mb-2">
-            <label class="form-label">최대 가격(원)</label>
+          <div class="form-group d-flex align-items-center mb-2">
+            <label class="form-label me-2 mb-0">최대 가격(원)</label>
             <input type="number" class="form-control form-control-sm" name="max_price" value="{{ config.get('max_price', 0) }}">
           </div>
-          <div class="mb-3">
-            <label class="form-label">거래량 순위</label>
+          <div class="form-group d-flex align-items-center mb-3">
+            <label class="form-label me-2 mb-0">거래량 순위</label>
             <input type="number" class="form-control form-control-sm" name="rank" value="{{ config.get('rank', 0) }}">
           </div>
           <button type="button" class="btn btn-primary btn-sm w-100" data-api="/api/save-settings">저장</button>
@@ -97,17 +100,19 @@
           <table class="table table-bordered text-center align-middle mb-0">
             <thead class="table-light">
               <tr>
-                <th>#</th><th>코인</th>
-                <th>손절·익절 그래프 <i class="bi bi-info-circle"></i></th>
-                <th>추세 손절·익절 <i class="bi bi-info-circle"></i></th>
-                <th>Sell 시그널</th>
-                <th>액션</th>
+                <th>코인</th>
+                <th>수익률 <i class="bi bi-exclamation-circle" data-bs-toggle="tooltip" title="현재 평가 손익률"></i></th>
+                <th>손절·익절 그래프 <i class="bi bi-exclamation-circle" data-bs-toggle="tooltip" title="손절가와 익절가를 시각화"></i></th>
+                <th>추세 손절·익절 <i class="bi bi-exclamation-circle" data-bs-toggle="tooltip" title="추세 기반 손절·익절 지점"></i></th>
+                <th>Sell 시그널 <i class="bi bi-exclamation-circle" data-bs-toggle="tooltip" title="매도 우선순위"></i></th>
+                <th>액션 <i class="bi bi-exclamation-circle" data-bs-toggle="tooltip" title="수동 매도"></i></th>
               </tr>
             </thead>
             <tbody id="positionBody">
               {% for p in positions %}
               <tr>
-                <td>{{ loop.index }}</td><td>{{ p.coin }}</td>
+                <td>{{ p.coin }}</td>
+                <td>{{ p.pnl }} %</td>
                 <td>
                   <div class="bar-graph">
                     <span class="dot stop"></span>


### PR DESCRIPTION
## Summary
- clarify bot status section with separate action button
- display coin filter inputs on single lines
- add PnL and tooltips to balance table
- compute coin profit rates server side
- refresh balances every 5 seconds

## Testing
- `python -m py_compile app.py bot/trader.py`