### PR TITLE
Fix strategy page layout

### DIFF
--- a/static/css/custom.css
+++ b/static/css/custom.css
@@ -98,3 +98,9 @@ input[type="password"] { letter-spacing:0.2em; }
   flex: 1;
   max-width: 160px;
 }
+
+/* Remove scroll limit for tables needing full height */
+.no-scroll {
+  max-height: none !important;
+  overflow: visible !important;
+}

--- a/static/js/main.js
+++ b/static/js/main.js
@@ -117,6 +117,7 @@ document.addEventListener('click', async e => {
   const result = await callApi(btn.dataset.api, data);
   if(['/save','/api/save-settings'].includes(btn.dataset.api) && result && result.result === 'success'){
     await loadStatus();
+    await reloadBuyMonitor();
   }
 });
 

--- a/templates/strategy.html
+++ b/templates/strategy.html
@@ -12,10 +12,12 @@
          title="10가지 매매 전략을 직접 선택·조합할 수 있습니다. 각 전략명을 마우스 오버하면 상세 설명과 실전 예시가 팝업됩니다."></i>
     </div>
     <div class="card-body">
-      <div class="section-label mb-3"><i class="bi bi-lightbulb"></i> 전략별 체크, 파라미터 설정, 상세 설명·예시</div>
+      <div class="section-label mb-3"><i class="bi bi-lightbulb"></i> 전략별 체크, 파라미터 설정, 상세 설명·예시
+        <i class="bi bi-exclamation-circle" data-bs-toggle="tooltip" title="필요한 전략만 체크하고 수익목표와 손절 등을 입력합니다."></i>
+      </div>
       <div class="form-text mb-4">아래 전략 중 원하는 것만 활성화할 수 있습니다. 각 전략명 옆의 <i class="bi bi-info-circle"></i>에 마우스를 올리면 진입 조건/설명/실전 예시가 나옵니다.<br>
       <b>예시:</b> M-BREAK 전략은 "5EMA &gt; 20EMA &gt; 60EMA, ATR≥0.035, 20봉 평균 거래량의 1.8배 이상 폭증, 전고점 돌파시 진입" 입니다.</div>
-      <div class="table-responsive mb-4">
+      <div class="table-responsive no-scroll mb-4">
         <table class="table table-bordered align-middle fs-106">
           <thead class="table-light">
             <tr>
@@ -78,7 +80,9 @@
          title="회당 최대 매수금, 동시매매 코인 수, 슬리피지(체결 오차), 잔고 소진시 알림/자동중지"></i>
     </div>
     <div class="card-body">
-      <div class="section-label mb-3"><i class="bi bi-lightbulb"></i> 전략별 체크, 파라미터 설정, 상세 설명·예시</div>
+      <div class="section-label mb-3"><i class="bi bi-lightbulb"></i> 전략별 체크, 파라미터 설정, 상세 설명·예시
+        <i class="bi bi-exclamation-circle" data-bs-toggle="tooltip" title="자금 관련 한도와 슬리피지 등을 설정합니다."></i>
+      </div>
       <div class="form-text mb-4">아래 전략 중 원하는 것만 활성화할 수 있습니다. 각 전략명 옆의 <i class="bi bi-info-circle"></i>에 마우스를 올리면 진입 조건/설명/실전 예시가 나옵니다.<br>
       <b>예시:</b> M-BREAK 전략은 "5EMA &gt; 20EMA &gt; 60EMA, ATR≥0.035, 20봉 평균 거래량의 1.8배 이상 폭증, 전고점 돌파시 진입" 입니다.</div>
       <form>
@@ -126,7 +130,9 @@
          title="운영시간, 정기 리밸런싱, 특정 이벤트(뉴스/점검 등) 자동 매매 중지 설정"></i>
     </div>
     <div class="card-body">
-      <div class="section-label mb-3"><i class="bi bi-lightbulb"></i> 전략별 체크, 파라미터 설정, 상세 설명·예시</div>
+      <div class="section-label mb-3"><i class="bi bi-lightbulb"></i> 전략별 체크, 파라미터 설정, 상세 설명·예시
+        <i class="bi bi-exclamation-circle" data-bs-toggle="tooltip" title="운영 시간과 스케줄 관련 자동화 옵션을 정합니다."></i>
+      </div>
       <div class="form-text mb-4">아래 전략 중 원하는 것만 활성화할 수 있습니다. 각 전략명 옆의 <i class="bi bi-info-circle"></i>에 마우스를 올리면 진입 조건/설명/실전 예시가 나옵니다.<br>
       <b>예시:</b> M-BREAK 전략은 "5EMA &gt; 20EMA &gt; 60EMA, ATR≥0.035, 20봉 평균 거래량의 1.8배 이상 폭증, 전고점 돌파시 진입" 입니다.</div>
       <form>
@@ -163,7 +169,9 @@
          title="백테스트, 캔들단위, 수수료, 지표튜닝, AI 최적화, 설정 내보내기/초기화 등"></i>
     </div>
     <div class="card-body">
-      <div class="section-label mb-3"><i class="bi bi-lightbulb"></i> 전략별 체크, 파라미터 설정, 상세 설명·예시</div>
+      <div class="section-label mb-3"><i class="bi bi-lightbulb"></i> 전략별 체크, 파라미터 설정, 상세 설명·예시
+        <i class="bi bi-exclamation-circle" data-bs-toggle="tooltip" title="백테스트, 지표튜닝 등 고급 옵션을 설정합니다."></i>
+      </div>
       <div class="form-text mb-4">아래 전략 중 원하는 것만 활성화할 수 있습니다. 각 전략명 옆의 <i class="bi bi-info-circle"></i>에 마우스를 올리면 진입 조건/설명/실전 예시가 나옵니다.<br>
       <b>예시:</b> M-BREAK 전략은 "5EMA &gt; 20EMA &gt; 60EMA, ATR≥0.035, 20봉 평균 거래량의 1.8배 이상 폭증, 전고점 돌파시 진입" 입니다.</div>
       <form>


### PR DESCRIPTION
## Summary
- allow entire strategy table to show without scroll
- add tutorial icons to each strategy section
- refresh buy monitor after saving settings

## Testing
- `python -m py_compile $(git ls-files '*.py')`