### PR TITLE
Add exclude list for sell monitoring

### DIFF
--- a/static/js/main.js
+++ b/static/js/main.js
@@ -118,6 +118,8 @@ document.addEventListener('click', async e => {
   if(['/save','/api/save-settings'].includes(btn.dataset.api) && result && result.result === 'success'){
     await loadStatus();
     await reloadBuyMonitor();
+  } else if(btn.dataset.api === '/api/exclude-coin' && result && result.result === 'success'){
+    await reloadBalance();
   }
 });
 
@@ -165,6 +167,7 @@ function updatePositions(list){
   body.innerHTML = list.map((p, i) => `
     <tr>
       <td>${i+1}</td><td>${p.coin}</td>
+      <td><button class="btn btn-sm btn-outline-primary text-dark" data-api="/api/exclude-coin" data-coin="${p.coin}">제외</button></td>
       <td>
         <div class="bar-graph">
           <span class="dot stop"></span>
@@ -238,6 +241,7 @@ function updateBalanceTable(list){
   body.innerHTML = list.map(p => `
     <tr>
       <td>${p.coin}</td>
+      <td><button class="btn btn-sm btn-outline-primary text-dark" data-api="/api/exclude-coin" data-coin="${p.coin}">제외</button></td>
       <td>${p.pnl} %</td>
       <td>
         <div class="bar-graph">
@@ -343,4 +347,26 @@ document.addEventListener('DOMContentLoaded', ()=>{
   setInterval(reloadBalance, 5000);
   reloadAccount();
   reloadBalance();
+  const btn = document.getElementById('btnExcludedList');
+  if(btn){
+    btn.addEventListener('click', async ()=>{
+      try{
+        const resp = await fetch('/api/excluded-coins');
+        const data = await resp.json();
+        if(data.result === 'success'){
+          const body = document.getElementById('excludeListBody');
+          if(body){
+            body.innerHTML = data.coins.length ?
+              data.coins.map(c=>`<tr><td>${c.coin}</td><td>${c.deleted}</td></tr>`).join('') :
+              '<tr><td colspan="2" class="text-muted py-3">없음</td></tr>';
+            new bootstrap.Modal(document.getElementById('excludeListModal')).show();
+          }
+        } else if(data.message){
+          showAlert(data.message, '에러');
+        }
+      }catch(err){
+        showAlert('서버 연결 오류. 네트워크 또는 서버를 확인해 주세요.', '에러');
+      }
+    });
+  }
 });

--- a/templates/base.html
+++ b/templates/base.html
@@ -55,6 +55,23 @@
     </div>
   </div>
 </div>
+<!-- 제외 목록 모달 -->
+<div class="modal fade" id="excludeListModal" tabindex="-1">
+  <div class="modal-dialog">
+    <div class="modal-content">
+      <div class="modal-header bg-primary text-white">
+        <h5 class="modal-title">제외 목록</h5>
+        <button type="button" class="btn-close btn-close-white" data-bs-dismiss="modal"></button>
+      </div>
+      <div class="modal-body p-0">
+        <table class="table table-bordered text-center mb-0">
+          <thead class="table-light"><tr><th>코인 ID</th><th>삭제 일</th></tr></thead>
+          <tbody id="excludeListBody"></tbody>
+        </table>
+      </div>
+    </div>
+  </div>
+</div>
 {% block content %}{% endblock %}
 <script src="https://cdn.jsdelivr.net/npm/bootstrap@5.3.3/dist/js/bootstrap.bundle.min.js"></script>
 <script src="/static/js/main.js"></script>

--- a/templates/index.html
+++ b/templates/index.html
@@ -90,7 +90,8 @@
     <div class="card shadow-sm mb-5">
       <div class="card-head">
         <i class="bi bi-cash-coin"></i> 보유코인 관리 (매도 모니터링)
-        <i class="bi bi-question-circle ms-auto" data-bs-toggle="tooltip"
+        <i id="btnExcludedList" class="bi bi-list-ul ms-auto" role="button" data-bs-toggle="tooltip" title="제외 코인 목록"></i>
+        <i class="bi bi-question-circle ms-2" data-bs-toggle="tooltip"
            title="현재 보유 중인 코인의 손익 상태와 매도(Exit) 우선순위를 모니터링합니다."></i>
         <i class="ms-2 bi bi-arrow-clockwise reload-btn" role="button" data-refresh="balances"
            data-bs-toggle="tooltip" title="데이터 새로 고침"></i>
@@ -101,6 +102,7 @@
             <thead class="table-light">
               <tr>
                 <th>코인</th>
+                <th>제외</th>
                 <th>수익률 <i class="bi bi-exclamation-circle" data-bs-toggle="tooltip" title="현재 평가 손익률"></i></th>
                 <th>손절·익절 그래프 <i class="bi bi-exclamation-circle" data-bs-toggle="tooltip" title="손절가와 익절가를 시각화"></i></th>
                 <th>추세 손절·익절 <i class="bi bi-exclamation-circle" data-bs-toggle="tooltip" title="추세 기반 손절·익절 지점"></i></th>
@@ -112,6 +114,7 @@
               {% for p in positions %}
               <tr>
                 <td>{{ p.coin }}</td>
+                <td><button class="btn btn-sm btn-outline-primary text-dark" data-api="/api/exclude-coin" data-coin="{{ p.coin }}">제외</button></td>
                 <td>{{ p.pnl }} %</td>
                 <td>
                   <div class="bar-graph">


### PR DESCRIPTION
## Summary
- add feature to exclude coins from sell monitoring
- persist excluded coins and filter dashboard/API results
- add modal to show excluded coin list
- update dashboard table and JS handlers

## Testing
- `python -m py_compile app.py`