### PR TITLE
Improve filter save input validation and add tests

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,6 +38,13 @@ python app.py
 The app runs with `socketio.run` so WebSocket notifications work by default.
 Real time events are pushed to the browser via SocketIO and displayed with `showAlert()` in `main.js`.
 
+## Running tests
+Install `pytest` and execute the suite:
+```bash
+pip install pytest
+pytest
+```
+
 ## Secrets configuration
 All API keys and tokens are read from `config/secrets.json`. Create the file before starting the server:
 

--- a/tests/test_signals.py
+++ b/tests/test_signals.py
@@ -1,0 +1,30 @@
+import importlib
+import app
+
+
+def reload_app():
+    importlib.reload(app)
+    return app
+
+
+def test_no_filters_returns_all():
+    reload_app()
+    app.filter_config = {"min_price": 0, "max_price": 0, "rank": 0}
+    result = app.get_filtered_signals()
+    assert len(result) == len(app.sample_signals)
+
+
+def test_min_price_filter():
+    reload_app()
+    app.filter_config = {"min_price": 1000, "max_price": 0, "rank": 0}
+    result = app.get_filtered_signals()
+    coins = [r["coin"] for r in result]
+    assert coins == ["BTC", "ETH"]
+
+
+def test_rank_filter():
+    reload_app()
+    app.filter_config = {"min_price": 0, "max_price": 0, "rank": 3}
+    result = app.get_filtered_signals()
+    coins = [r["coin"] for r in result]
+    assert coins == ["BTC", "ETH"]


### PR DESCRIPTION
## Summary
- validate numeric values in `/api/save-settings`
- log the monitored coins after filtering
- add pytest-based unit tests for `get_filtered_signals`
- document how to run the tests

## Testing
- `python -m py_compile $(git ls-files '*.py')`
- `pytest -q` *(fails: command not found)*