### PR TITLE
Apply filter settings to trading tickers

### DIFF
--- a/bot/trader.py
+++ b/bot/trader.py
@@ -17,8 +17,15 @@ class UpbitTrader:
         self.running = False    # 봇 실행 여부
         self.logger = logger    # 로거
         self.thread = None      # 실행 스레드
+        self.tickers = config.get("tickers", ["KRW-BTC", "KRW-ETH"])
         if self.logger:
             self.logger.debug("Trader initialized with config %s", config)
+
+    def set_tickers(self, tickers: list[str]) -> None:
+        """Update trading tickers list."""
+        self.tickers = tickers
+        if self.logger:
+            self.logger.info("[TRADER] Tickers updated: %s", tickers)
 
     def start(self) -> bool:
         """자동매매 시작 (스레드)"""
@@ -55,7 +62,7 @@ class UpbitTrader:
             try:
                 if self.logger:
                     self.logger.debug("run_loop iteration")
-                tickers = self.config.get("tickers", ["KRW-BTC", "KRW-ETH"])
+                tickers = self.tickers or self.config.get("tickers", ["KRW-BTC", "KRW-ETH"])
                 strat_name = self.config.get("strategy", "M-BREAK")
                 params = self.config.get("params", {})
                 if self.logger:

--- a/tests/test_signals.py
+++ b/tests/test_signals.py
@@ -28,3 +28,17 @@ def test_rank_filter():
     result = app.get_filtered_signals()
     coins = [r["coin"] for r in result]
     assert coins == ["BTC", "ETH"]
+
+
+def test_filtered_tickers_no_filters():
+    reload_app()
+    app.filter_config = {"min_price": 0, "max_price": 0, "rank": 0}
+    tickers = app.get_filtered_tickers()
+    assert tickers == app.config_data.get("tickers")
+
+
+def test_filtered_tickers_min_price():
+    reload_app()
+    app.filter_config = {"min_price": 1000, "max_price": 0, "rank": 0}
+    tickers = app.get_filtered_tickers()
+    assert tickers == ["KRW-BTC", "KRW-ETH", "KRW-ADA"]


### PR DESCRIPTION
## Summary
- connect dashboard filter to trading logic
- expose filtered tickers via `get_filtered_tickers`
- update `UpbitTrader` to allow updating tickers
- adjust tests for new helper

## Testing
- `pytest -q` *(fails: command not found)*