### PR TITLE
Use file-based signals for monitoring

### DIFF
--- a/CODE_OVERVIEW_KR.md
+++ b/CODE_OVERVIEW_KR.md
@@ -19,6 +19,7 @@
 ## config 디렉터리
 - **config/config.json**: 예제 설정 값.
 - **config/secrets.json**: API 키 등 비밀 정보 예시.
+- **config/market.json**: 대시보드에서 사용하는 샘플 시그널 데이터.
 
 ## templates 디렉터리 (Jinja2 HTML)
 - **base.html**: 기본 레이아웃.

--- a/README.md
+++ b/README.md
@@ -8,6 +8,7 @@ This repository contains a minimal Flask + SocketIO demo for an automated tradin
   Each template gets variables like `positions`, `strategies`, `alerts` or `settings` directly from Flask.
 - **static/js/main.js** – Common JavaScript handling API calls, SocketIO events, draggable layout and real time table updates.
 - **static/css/custom.css** – Consolidated styles for all pages with no inline styles left in templates.
+- **config/market.json** – Sample market data loaded for monitoring filters.
 
 ## Example variables passed to templates
 ```python

--- a/bot/trader.py
+++ b/bot/trader.py
@@ -17,8 +17,15 @@ class UpbitTrader:
         self.running = False    # 봇 실행 여부
         self.logger = logger    # 로거
         self.thread = None      # 실행 스레드
+        self.tickers = config.get("tickers", ["KRW-BTC", "KRW-ETH"])
         if self.logger:
             self.logger.debug("Trader initialized with config %s", config)
+
+    def set_tickers(self, tickers: list[str]) -> None:
+        """Update trading tickers list."""
+        self.tickers = tickers
+        if self.logger:
+            self.logger.info("[TRADER] Tickers updated: %s", tickers)
 
     def start(self) -> bool:
         """자동매매 시작 (스레드)"""
@@ -55,7 +62,7 @@ class UpbitTrader:
             try:
                 if self.logger:
                     self.logger.debug("run_loop iteration")
-                tickers = self.config.get("tickers", ["KRW-BTC", "KRW-ETH"])
+                tickers = self.tickers or self.config.get("tickers", ["KRW-BTC", "KRW-ETH"])
                 strat_name = self.config.get("strategy", "M-BREAK")
                 params = self.config.get("params", {})
                 if self.logger:

--- a/config/market.json
+++ b/config/market.json
@@ -1,0 +1,6 @@
+[
+  {"coin": "BTC", "price": 40000000, "rank": 1, "trend": "🔼", "volatility": "🔵 5.8", "volume": "⏫ 250", "strength": "⏫ 122", "gc": "🔼", "rsi": "⏫ E", "signal": "강제 매수", "signal_class": "go", "key": "MBREAK"},
+  {"coin": "ETH", "price": 2500000, "rank": 2, "trend": "🔼", "volatility": "🔵 4.2", "volume": "⏫ 180", "strength": "🔼 80", "gc": "🔼", "rsi": "🔸 55", "signal": "관망", "signal_class": "wait", "key": "MBREAK"},
+  {"coin": "XRP", "price": 600, "rank": 5, "trend": "🔸", "volatility": "🟡 3.1", "volume": "🔼 90", "strength": "🔻 40", "gc": "🔻", "rsi": "🔸 50", "signal": "관망", "signal_class": "wait", "key": "MBREAK"},
+  {"coin": "DOGE", "price": 150, "rank": 20, "trend": "🔻", "volatility": "🔻 1.5", "volume": "🔻 30", "strength": "🔻 20", "gc": "🔻", "rsi": "🔻 70", "signal": "회피", "signal_class": "avoid", "key": "MBREAK"}
+]

--- a/tests/test_signals.py
+++ b/tests/test_signals.py
@@ -1,4 +1,5 @@
 import importlib
+import json
 import app
 
 
@@ -7,11 +8,16 @@ def reload_app():
     return app
 
 
+def load_signals():
+    with open(app.MARKET_FILE, encoding="utf-8") as f:
+        return json.load(f)
+
+
 def test_no_filters_returns_all():
     reload_app()
     app.filter_config = {"min_price": 0, "max_price": 0, "rank": 0}
     result = app.get_filtered_signals()
-    assert len(result) == len(app.sample_signals)
+    assert len(result) == len(load_signals())
 
 
 def test_min_price_filter():
@@ -28,3 +34,17 @@ def test_rank_filter():
     result = app.get_filtered_signals()
     coins = [r["coin"] for r in result]
     assert coins == ["BTC", "ETH"]
+
+
+def test_filtered_tickers_no_filters():
+    reload_app()
+    app.filter_config = {"min_price": 0, "max_price": 0, "rank": 0}
+    tickers = app.get_filtered_tickers()
+    assert tickers == app.config_data.get("tickers")
+
+
+def test_filtered_tickers_min_price():
+    reload_app()
+    app.filter_config = {"min_price": 1000, "max_price": 0, "rank": 0}
+    tickers = app.get_filtered_tickers()
+    assert tickers == ["KRW-BTC", "KRW-ETH", "KRW-ADA"]


### PR DESCRIPTION
## Summary
- load signal data from `config/market.json` instead of hard-coded list
- update ticker filtering to use the loaded market data
- document the new sample data file
- adjust tests for the new behaviour

## Testing
- `python -m py_compile app.py bot/trader.py utils.py tests/test_signals.py`
- `pytest -q` *(fails: command not found)*