### PR TITLE
Enable live Upbit monitoring

### DIFF
--- a/CODE_OVERVIEW_KR.md
+++ b/CODE_OVERVIEW_KR.md
@@ -15,6 +15,7 @@
 - **bot/indicators.py**: EMA, RSI 등 기술적 지표 계산 함수.
 - **bot/strategy.py**: 9가지 매매 전략 함수와 선택 로직.
 - **bot/trader.py**: 업비트 API를 활용한 메인 트레이더 클래스.
+- **app.py/load_market_signals**: 1분마다 업비트 시세와 거래량을 불러와 필터링에 사용.
 
 ## config 디렉터리
 - **config/config.json**: 예제 설정 값.

--- a/README.md
+++ b/README.md
@@ -28,6 +28,12 @@ Buttons with a `data-api` attribute automatically send the nearest form data via
 The JavaScript in `main.js` will call `/api/start-bot` and show any returned message via a modal.
 SocketIO events `notification`, `positions` and `alerts` push real time updates to the browser.
 
+## Market data
+`app.py` retrieves current prices and 24h volume from Upbit once per minute. The
+coins are filtered by the values in `config/filter.json` (`min_price`,
+`max_price`, `rank`), and this filtered list controls both monitoring and real
+trading targets.
+
 ## Running
 Install requirements and start the server:
 ```bash

--- a/bot/trader.py
+++ b/bot/trader.py
@@ -17,8 +17,15 @@ class UpbitTrader:
         self.running = False    # 봇 실행 여부
         self.logger = logger    # 로거
         self.thread = None      # 실행 스레드
+        self.tickers = config.get("tickers", ["KRW-BTC", "KRW-ETH"])
         if self.logger:
             self.logger.debug("Trader initialized with config %s", config)
+
+    def set_tickers(self, tickers: list[str]) -> None:
+        """Update trading tickers list."""
+        self.tickers = tickers
+        if self.logger:
+            self.logger.info("[TRADER] Tickers updated: %s", tickers)
 
     def start(self) -> bool:
         """자동매매 시작 (스레드)"""
@@ -55,7 +62,7 @@ class UpbitTrader:
             try:
                 if self.logger:
                     self.logger.debug("run_loop iteration")
-                tickers = self.config.get("tickers", ["KRW-BTC", "KRW-ETH"])
+                tickers = self.tickers or self.config.get("tickers", ["KRW-BTC", "KRW-ETH"])
                 strat_name = self.config.get("strategy", "M-BREAK")
                 params = self.config.get("params", {})
                 if self.logger:

--- a/tests/test_signals.py
+++ b/tests/test_signals.py
@@ -1,9 +1,18 @@
 import importlib
+import time
 import app
+
+sample_data = [
+    {"coin": "BTC", "price": 40000000, "rank": 1, "trend": "", "volatility": "", "volume": "", "strength": "", "gc": "", "rsi": "", "signal": "", "signal_class": "", "key": "MBREAK"},
+    {"coin": "ETH", "price": 2500000, "rank": 2, "trend": "", "volatility": "", "volume": "", "strength": "", "gc": "", "rsi": "", "signal": "", "signal_class": "", "key": "MBREAK"},
+    {"coin": "XRP", "price": 600, "rank": 5, "trend": "", "volatility": "", "volume": "", "strength": "", "gc": "", "rsi": "", "signal": "", "signal_class": "", "key": "MBREAK"},
+]
 
 
 def reload_app():
     importlib.reload(app)
+    app.market_signals = sample_data
+    app.market_updated = time.time()
     return app
 
 
@@ -11,7 +20,7 @@ def test_no_filters_returns_all():
     reload_app()
     app.filter_config = {"min_price": 0, "max_price": 0, "rank": 0}
     result = app.get_filtered_signals()
-    assert len(result) == len(app.sample_signals)
+    assert len(result) == len(sample_data)
 
 
 def test_min_price_filter():
@@ -28,3 +37,17 @@ def test_rank_filter():
     result = app.get_filtered_signals()
     coins = [r["coin"] for r in result]
     assert coins == ["BTC", "ETH"]
+
+
+def test_filtered_tickers_no_filters():
+    reload_app()
+    app.filter_config = {"min_price": 0, "max_price": 0, "rank": 0}
+    tickers = app.get_filtered_tickers()
+    assert tickers == app.config_data.get("tickers")
+
+
+def test_filtered_tickers_min_price():
+    reload_app()
+    app.filter_config = {"min_price": 1000, "max_price": 0, "rank": 0}
+    tickers = app.get_filtered_tickers()
+    assert tickers == ["KRW-BTC", "KRW-ETH", "KRW-ADA"]


### PR DESCRIPTION
## Summary
- fetch ticker prices and volume from Upbit once per minute
- filter monitoring and trade tickers using fresh market data
- document market data refresh and loader function
- adjust unit tests for the new dynamic signal list

## Testing
- `python -m py_compile app.py bot/trader.py utils.py tests/test_signals.py`
- `pytest -q` *(fails: command not found)*