### PR TITLE
Fix market loader

### DIFF
--- a/CODE_OVERVIEW_KR.md
+++ b/CODE_OVERVIEW_KR.md
@@ -17,8 +17,9 @@
 - **bot/trader.py**: 업비트 API를 활용한 메인 트레이더 클래스.
 
 ## config 디렉터리
-- **config/config.json**: 예제 설정 값.
-- **config/secrets.json**: API 키 등 비밀 정보 예시.
+ - **config/config.json**: 예제 설정 값.
+ - **config/secrets.json**: API 키 등 비밀 정보 예시.
+ - **config/market.json**: 업비트 연결 실패 시 사용할 시세 예시 데이터.
 
 ## templates 디렉터리 (Jinja2 HTML)
 - **base.html**: 기본 레이아웃.

--- a/README.md
+++ b/README.md
@@ -67,6 +67,9 @@ Example error:
 [ERROR] Missing required secrets: UPBIT_KEY, UPBIT_SECRET
 ```
 
+`config/market.json` stores fallback market data when live fetching from Upbit
+fails. Tests load this file to avoid network access.
+
 ## Windows 설치 가이드
 Windows 10/11 + Visual Studio C++ 빌드툴 환경에서 다음 순서로 준비합니다.
 

--- a/app.py
+++ b/app.py
@@ -175,22 +175,54 @@ def save_excluded():
 
 positions = []
 
-sample_signals = [
-    {"coin": "BTC", "price": 40000000, "rank": 1, "trend": "🔼", "volatility": "🔵 5.8", "volume": "⏫ 250", "strength": "⏫ 122", "gc": "🔼", "rsi": "⏫ E", "signal": "강제 매수", "signal_class": "go", "key": "MBREAK"},
-    {"coin": "ETH", "price": 2500000, "rank": 2, "trend": "🔼", "volatility": "🔵 4.2", "volume": "⏫ 180", "strength": "🔼 80", "gc": "🔼", "rsi": "🔸 55", "signal": "관망", "signal_class": "wait", "key": "MBREAK"},
-    {"coin": "XRP", "price": 600, "rank": 5, "trend": "🔸", "volatility": "🟡 3.1", "volume": "🔼 90", "strength": "🔻 40", "gc": "🔻", "rsi": "🔸 50", "signal": "관망", "signal_class": "wait", "key": "MBREAK"},
-    {"coin": "DOGE", "price": 150, "rank": 20, "trend": "🔻", "volatility": "🔻 1.5", "volume": "🔻 30", "strength": "🔻 20", "gc": "🔻", "rsi": "🔻 70", "signal": "회피", "signal_class": "avoid", "key": "MBREAK"},
-]
+MARKET_FILE = "config/market.json"
+market_signals: list[dict] = []
+
+
+def load_market_signals(path: str | None = None) -> list[dict]:
+    """Fetch current market data from Upbit or ``MARKET_FILE``."""
+    if path is None:
+        path = MARKET_FILE
+    try:  # try live fetch
+        import pyupbit
+
+        tickers = pyupbit.get_tickers(fiat="KRW")
+        info = pyupbit.get_market_ticker(tickers)
+        info.sort(key=lambda x: x.get("acc_trade_price_24h", 0), reverse=True)
+        result = []
+        for i, t in enumerate(info, start=1):
+            result.append(
+                {
+                    "coin": t["market"].split("-")[1],
+                    "price": t.get("trade_price", 0),
+                    "rank": i,
+                }
+            )
+        return result
+    except Exception as e:  # noqa: BLE001
+        logger.error("Failed to load market data: %s", e, exc_info=True)
+        if os.path.exists(path):
+            try:
+                with open(path, encoding="utf-8") as f:
+                    return json.load(f)
+            except Exception as e2:  # noqa: BLE001
+                logger.error("Failed to load market file: %s", e2)
+        return []
+
+
+market_signals = load_market_signals()
 
 def get_filtered_signals():
-    """Return sample signals filtered by price range and volume rank."""
+    """Return market signals filtered by price and volume rank."""
     logger.info("[MONITOR] 매수 모니터링 요청")
     logger.debug("[MONITOR] 필터 조건 %s", filter_config)
     min_p = float(filter_config.get("min_price", 0) or 0)
     max_p = float(filter_config.get("max_price", 0) or 0)
     rank = int(filter_config.get("rank", 0) or 0)
     result = []
-    for s in sample_signals:
+    global market_signals
+    market_signals = load_market_signals()
+    for s in market_signals:
         logger.debug("[MONITOR] 원본 시그널 %s", s)
         if min_p and s["price"] < min_p:
             continue
@@ -206,13 +238,39 @@ def get_filtered_signals():
         logger.debug("[MONITOR] 응답 데이터 %s", s)
     return result
 
+def get_filtered_tickers() -> list[str]:
+    """Return config tickers filtered by dashboard conditions."""
+    logger.debug("Filtering tickers with %s", filter_config)
+    tickers = config_data.get("tickers", [])
+    if not tickers:
+        return []
+    min_p = float(filter_config.get("min_price", 0) or 0)
+    max_p = float(filter_config.get("max_price", 0) or 0)
+    rank = int(filter_config.get("rank", 0) or 0)
+    result = []
+    for t in tickers:
+        coin = t.split("-")[-1]
+        sig = next((s for s in market_signals if s.get("coin") == coin), None)
+        if sig:
+            price = sig.get("price", 0)
+            r = sig.get("rank", 0)
+            if min_p and price < min_p:
+                continue
+            if max_p and max_p > 0 and price > max_p:
+                continue
+            if rank and r > rank:
+                continue
+        result.append(t)
+    logger.debug("Filtered tickers: %s", result)
+    return result
+
 alerts = []
 history = [
     {"time": "2025-05-18 13:00", "label": "적용", "cls": "success"},
     {"time": "2025-05-17 10:13", "label": "분석", "cls": "primary"},
 ]
-buy_results = sample_signals
-sell_results = sample_signals
+buy_results = market_signals
+sell_results = market_signals
 
 # 기본 전략 정보 (9전략 모두 표시)
 strategies = [
@@ -538,6 +596,7 @@ def start_bot():
     logger.debug("start_bot called")
     logger.info("[API] 봇 시작 요청")
     try:
+        trader.set_tickers(get_filtered_tickers())
         started = trader.start()
         if not started:
             logger.info("Start request ignored: already running")

--- a/bot/trader.py
+++ b/bot/trader.py
@@ -17,8 +17,15 @@ class UpbitTrader:
         self.running = False    # 봇 실행 여부
         self.logger = logger    # 로거
         self.thread = None      # 실행 스레드
+        self.tickers = config.get("tickers", ["KRW-BTC", "KRW-ETH"])
         if self.logger:
             self.logger.debug("Trader initialized with config %s", config)
+
+    def set_tickers(self, tickers: list[str]) -> None:
+        """Update trading tickers list."""
+        self.tickers = tickers
+        if self.logger:
+            self.logger.info("[TRADER] Tickers updated: %s", tickers)
 
     def start(self) -> bool:
         """자동매매 시작 (스레드)"""
@@ -55,7 +62,7 @@ class UpbitTrader:
             try:
                 if self.logger:
                     self.logger.debug("run_loop iteration")
-                tickers = self.config.get("tickers", ["KRW-BTC", "KRW-ETH"])
+                tickers = self.tickers or self.config.get("tickers", ["KRW-BTC", "KRW-ETH"])
                 strat_name = self.config.get("strategy", "M-BREAK")
                 params = self.config.get("params", {})
                 if self.logger:

--- a/config/market.json
+++ b/config/market.json
@@ -1,0 +1,6 @@
+[
+  {"coin": "BTC", "price": 40000000, "rank": 1},
+  {"coin": "ETH", "price": 2500000, "rank": 2},
+  {"coin": "XRP", "price": 600, "rank": 5},
+  {"coin": "DOGE", "price": 150, "rank": 20}
+]

--- a/tests/test_signals.py
+++ b/tests/test_signals.py
@@ -4,6 +4,7 @@ import app
 
 def reload_app():
     importlib.reload(app)
+    app.market_signals = app.load_market_signals()
     return app
 
 
@@ -11,7 +12,7 @@ def test_no_filters_returns_all():
     reload_app()
     app.filter_config = {"min_price": 0, "max_price": 0, "rank": 0}
     result = app.get_filtered_signals()
-    assert len(result) == len(app.sample_signals)
+    assert len(result) == len(app.market_signals)
 
 
 def test_min_price_filter():
@@ -28,3 +29,17 @@ def test_rank_filter():
     result = app.get_filtered_signals()
     coins = [r["coin"] for r in result]
     assert coins == ["BTC", "ETH"]
+
+
+def test_filtered_tickers_no_filters():
+    reload_app()
+    app.filter_config = {"min_price": 0, "max_price": 0, "rank": 0}
+    tickers = app.get_filtered_tickers()
+    assert tickers == app.config_data.get("tickers")
+
+
+def test_filtered_tickers_min_price():
+    reload_app()
+    app.filter_config = {"min_price": 1000, "max_price": 0, "rank": 0}
+    tickers = app.get_filtered_tickers()
+    assert tickers == ["KRW-BTC", "KRW-ETH", "KRW-ADA"]


### PR DESCRIPTION
## Summary
- load real coin data with `load_market_signals`
- reference the refreshed signals from dashboard filtering
- store fallback ticker info in `config/market.json`
- update docs for the new file
- adjust unit tests to use `market_signals`

## Testing
- `python -m py_compile app.py bot/trader.py utils.py tests/test_signals.py`
- `pytest -q` *(fails: command not found)*