### PR TITLE
Add restore coin button to excluded list

### DIFF
--- a/app.py
+++ b/app.py
@@ -813,6 +813,24 @@ def exclude_coin():
         notify_error(f"제외 실패: {e}")
         return jsonify(result="error", message="제외 실패"), 500
 
+@app.route("/api/restore-coin", methods=["POST"])
+def restore_coin():
+    data = request.get_json(silent=True) or {}
+    coin = data.get('coin')
+    logger.debug("restore_coin called for %s", coin)
+    try:
+        if not coin:
+            raise ValueError("Invalid coin")
+        global excluded_coins
+        new_list = [c for c in excluded_coins if c.get('coin') != coin]
+        if len(new_list) != len(excluded_coins):
+            excluded_coins = new_list
+            save_excluded()
+        return jsonify(result="success", message=f"{coin} 복구됨")
+    except Exception as e:
+        notify_error(f"복구 실패: {e}")
+        return jsonify(result="error", message="복구 실패"), 500
+
 @app.route("/api/excluded-coins", methods=["GET"])
 def get_excluded_coins():
     logger.debug("get_excluded_coins called")

--- a/static/js/main.js
+++ b/static/js/main.js
@@ -113,6 +113,14 @@ document.addEventListener('click', async e => {
     await reloadBuyMonitor();
   } else if(btn.dataset.api === '/api/exclude-coin' && result && result.result === 'success'){
     await reloadBalance();
+  } else if(btn.dataset.api === '/api/restore-coin' && result && result.result === 'success'){
+    await reloadBalance();
+    const row = btn.closest('tr');
+    if(row) row.remove();
+    const body = document.getElementById('excludeListBody');
+    if(body && !body.querySelector('tr')){
+      body.innerHTML = '<tr><td colspan="3" class="text-muted py-3">없음</td></tr>';
+    }
   }
 });
 
@@ -352,8 +360,17 @@ document.addEventListener('DOMContentLoaded', ()=>{
           const body = document.getElementById('excludeListBody');
           if(body){
             body.innerHTML = data.coins.length ?
-              data.coins.map(c=>`<tr><td>${c.coin}</td><td>${c.deleted}</td></tr>`).join('') :
-              '<tr><td colspan="2" class="text-muted py-3">없음</td></tr>';
+              data.coins.map(c => `
+                <tr>
+                  <td>${c.coin}</td>
+                  <td>${c.deleted}</td>
+                  <td>
+                    <button class="btn btn-sm btn-outline-primary"
+                            data-api="/api/restore-coin"
+                            data-coin="${c.coin}">복구</button>
+                  </td>
+                </tr>`).join('') :
+              '<tr><td colspan="3" class="text-muted py-3">없음</td></tr>';
             new bootstrap.Modal(document.getElementById('excludeListModal')).show();
           }
         } else if(data.message){

--- a/templates/base.html
+++ b/templates/base.html
@@ -65,7 +65,7 @@
       </div>
       <div class="modal-body p-0">
         <table class="table table-bordered text-center mb-0">
-          <thead class="table-light"><tr><th>코인 ID</th><th>삭제 일</th></tr></thead>
+          <thead class="table-light"><tr><th>코인 ID</th><th>삭제 일</th><th>복구</th></tr></thead>
           <tbody id="excludeListBody"></tbody>
         </table>
       </div>


### PR DESCRIPTION
## Summary
- allow restoring excluded coins via `/api/restore-coin`
- add "복구" column in excluded list modal
- update JS to show restore button and update list on restore

## Testing
- `pytest -q` *(fails: command not found)*