### PR TITLE
Fix: log A002 disconnect without popup

### DIFF
--- a/static/js/main.js
+++ b/static/js/main.js
@@ -13,8 +13,12 @@ function handleDisconnect(code) {
   if (disconnected) return;
 
   const msg = `서버 연결 오류(${code}). 네트워크 또는 서버를 확인해 주세요.`;
-  console.error(`[NET-${code}] disconnect`);
-  showAlert(msg, '에러');
+  if (code === 'A002') {
+    console.debug(`[NET-${code}] ${msg}`);
+  } else {
+    console.error(`[NET-${code}] disconnect`);
+    showAlert(msg, '에러');
+  }
   disconnected = true;
 }
 


### PR DESCRIPTION
## Summary
- when balance refresh disconnects (A002) log it at debug level and avoid popup

## Testing
- `pytest -q` *(fails: command not found)*