### PR TITLE
Suppress signal API popups

### DIFF
--- a/app.py
+++ b/app.py
@@ -379,10 +379,12 @@ def buy_signal_monitor_loop() -> None:
                 coins = json.load(f)
         except Exception:
             coins = []
+        time.sleep(1)
         results = []
         for c in coins:
             ticker = f"KRW-{c['coin']}"
             results.append(calc_buy_signal(ticker, c["coin"]))
+        time.sleep(1)
         with _signal_lock:
             signal_cache = results
         logger.debug("[BUY MONITOR] updated %d signals", len(results))

--- a/static/js/main.js
+++ b/static/js/main.js
@@ -13,7 +13,7 @@ function handleDisconnect(code) {
   if (disconnected) return;
 
   const msg = `서버 연결 오류(${code}). 네트워크 또는 서버를 확인해 주세요.`;
-  if (code === 'A002') {
+  if (code === 'A002' || code === 'A003') {
     console.debug(`[NET-${code}] ${msg}`);
   } else {
     console.error(`[NET-${code}] disconnect`);
@@ -287,7 +287,7 @@ async function reloadBalance(){
     console.log('[API-A002] GET /api/balances', data);
     if (data.result === 'success' && data.balances) {
       if (disconnected) {
-        showAlert('서버 연결이 복구되었습니다.', '안내');
+        console.log('서버 연결이 복구되었습니다.');
       }
       disconnected = false;
       updateBalanceTable(data.balances);


### PR DESCRIPTION
## Summary
- avoid showing popups when `/api/signals` request fails
- delay buy monitor calculations as requested
- suppress reconnection popup message

## Testing
- `pip install pytest` *(fails: no network)*
- `pytest -q` *(command not found)*