### PR TITLE
Add TIS calculation using tick data

### DIFF
--- a/app.py
+++ b/app.py
@@ -9,7 +9,7 @@ import logging
 import json  # 기본 모듈들
 from datetime import datetime
 
-from utils import load_secrets, send_telegram, setup_logging
+from utils import load_secrets, send_telegram, setup_logging, calc_tis
 from bot.trader import UpbitTrader
 from bot.runtime_settings import settings, load_from_file
 import pyupbit
@@ -296,14 +296,7 @@ def calc_buy_signal(ticker: str, coin: str) -> dict:
         else:
             entry["volume"] = f"🔻 {vol_ratio:.2f}"
 
-        try:
-            ticks = pyupbit.get_ticks(ticker, count=30)
-            df_tick = pd.DataFrame(ticks)
-            buy_qty = df_tick[df_tick["ask_bid"] == "BID"]["trade_volume"].sum()
-            sell_qty = df_tick[df_tick["ask_bid"] == "ASK"]["trade_volume"].sum()
-            tis = (buy_qty / (sell_qty + 1e-9)) * 100
-        except Exception:
-            tis = None
+        tis = calc_tis(ticker)
         if tis is not None:
             if tis >= 120:
                 entry["strength"] = f"⏫ {tis:.0f}"

--- a/bot/trader.py
+++ b/bot/trader.py
@@ -7,6 +7,7 @@ import time           # 주기적 실행을 위한 시간 모듈
 import threading      # 스레드 사용을 위해
 import pandas as pd   # 데이터프레임 처리
 import pyupbit        # 업비트 API 연동
+from utils import calc_tis
 from .strategy import select_strategy
 from .indicators import calc_indicators
 
@@ -105,8 +106,7 @@ class UpbitTrader:
                     if self.logger:
                         last = df.iloc[-1].to_dict()
                         self.logger.debug("Indicators %s", last)
-                    # 실시간 체결강도, 예시용 (0~200)
-                    tis = 120  # 예시 체결강도 (0~200)
+                    tis = calc_tis(ticker) or 0
                     ok, strat_params = select_strategy(strat_name, df, tis, params)
                     if self.logger:
                         self.logger.debug(

--- a/docs/BUY_MONITOR_SPEC_KR.md
+++ b/docs/BUY_MONITOR_SPEC_KR.md
@@ -61,6 +61,7 @@
   ```python
   tis = df['buy_qty'] / df['sell_qty'] * 100
   ```
+  - `buy_qty`, `sell_qty` 값은 `/v1/trades/ticks` 체결 데이터를 최근 5분 동안 집계해 계산합니다.
 - **아이콘**: ⏫ ≥120, 🔼 105–119, 🔸 95–104, 🔻<95
 - **UI 예시**: `<span class="tis-high">⏫ 135</span>`
 


### PR DESCRIPTION
## Summary
- compute trade intensity strength (TIS) from recent trade ticks
- use the new helper in the dashboard buy monitor
- use the helper inside `UpbitTrader`
- document TIS tick aggregation in the spec

## Testing
- `pytest -q` *(fails: command not found)*