### PR TITLE
Fix Docker image vulnerability warning

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,7 @@
-FROM python:3.11-slim
+FROM python:3.11-slim-bullseye
 WORKDIR /app
 COPY . /app
+RUN apt-get update && apt-get upgrade -y \
+    && apt-get clean && rm -rf /var/lib/apt/lists/*
 RUN pip install --no-cache-dir -r requirements.txt
 CMD ["gunicorn", "-k", "eventlet", "-w", "1", "-b", "0.0.0.0:8000", "app:app"]


### PR DESCRIPTION
## Summary
- update the base image in the Dockerfile to a newer debian release
- run apt package upgrades during build for security

## Testing
- `pytest -q` *(fails: command not found)*