### PR TITLE
Implement 5‑minute monitor refresh and extra logging

### DIFF
--- a/static/css/custom.css
+++ b/static/css/custom.css
@@ -3,7 +3,17 @@
 body { background: #f6f8fb; color: #22315a; font-family: 'Noto Sans KR', sans-serif; font-size: 18px; }
 .navbar { background: #1e2b45 !important; }
 .card { border-radius: 1.25rem; box-shadow: 0 4px 24px #0001; margin-bottom: 2.5rem; }
-.card-head { background: #22315a; color: #fff; font-size: 1.25rem; font-weight: 600; padding: 1.2rem 2rem; display: flex; align-items: center; gap: .7rem; border-radius: 1.25rem 1.25rem 0 0; }
+.card-head {
+  background: #22315a;
+  color: #fff;
+  font-size: 1.25rem;
+  font-weight: 600;
+  padding: 1.2rem 2rem;
+  display: flex;
+  align-items: center;
+  gap: .7rem;
+  border-radius: 1.25rem 1.25rem 0 0;
+}
 .card-body { padding: 2.5rem; }
 .btn-primary, .btn-success { border-radius: 0.75rem; font-weight: 600; }
 .table th, .table td { vertical-align: middle; }
@@ -33,11 +43,27 @@ body { background: #f6f8fb; color: #22315a; font-family: 'Noto Sans KR', sans-se
 .badge-sell-wait { background: #6c757d; font-size: .8rem; padding: .36rem .85rem; }
 .bar-graph { width: 190px; margin: 0 auto; }
 .se-bar { width: 190px; margin: 0 auto; position: relative; height: 16px; background: #e9ecef; border-radius: 7px; }
-.se-bar .pin { position: absolute; top: 50%; transform: translate(-50%, -50%); width: 9px; height: 9px; border-radius: 50%; background: #0d6efd; }
+.se-bar .pin {
+  position: absolute;
+  top: 50%;
+  transform: translate(-50%, -50%);
+  width: 9px;
+  height: 9px;
+  border-radius: 50%;
+  background: #0d6efd;
+}
 .badge-profit { background:#198754; font-size:.8rem; padding:.36rem .85rem; }
 .badge-loss { background:#dc3545; font-size:.8rem; padding:.36rem .85rem; }
 .trend-bar { width: 170px; margin: 0 auto; }
-.trend-bar .trend-pin { position: absolute; top: 50%; transform: translate(-50%, -50%); width: 9px; height: 9px; border-radius: 50%; background: #6c757d; }
+.trend-bar .trend-pin {
+  position: absolute;
+  top: 50%;
+  transform: translate(-50%, -50%);
+  width: 9px;
+  height: 9px;
+  border-radius: 50%;
+  background: #6c757d;
+}
 .dot { position: absolute; top: 50%; transform: translateY(-50%); width: 15px; height: 15px; border-radius: 50%; }
 .dot.stop { background: #dc3545; left: 0; }
 .dot.entry { background: #6c757d; }
@@ -108,4 +134,11 @@ input[type="password"] { letter-spacing:0.2em; }
 .no-scroll {
   max-height: none !important;
   overflow: visible !important;
+}
+
+.remain-time {
+  flex: 1;
+  text-align: center;
+  font-size: 0.9rem;
+  color: #fff;
 }

--- a/templates/index.html
+++ b/templates/index.html
@@ -90,6 +90,7 @@
     <div class="card shadow-sm mb-5">
       <div class="card-head">
         <i class="bi bi-cash-coin"></i> 보유코인 관리 (매도 모니터링)
+        <span id="balanceTimer" class="remain-time"></span>
         <i id="btnExcludedList" class="bi bi-list-ul ms-auto" role="button" data-bs-toggle="tooltip" title="제외 코인 목록"></i>
         <i class="bi bi-question-circle ms-2" data-bs-toggle="tooltip"
            title="현재 보유 중인 코인의 손익 상태와 매도(Exit) 우선순위를 모니터링합니다."></i>
@@ -154,6 +155,7 @@
     <div class="card shadow-sm">
       <div class="card-head">
         <i class="bi bi-bullseye"></i> 매수 모니터링
+        <span id="signalTimer" class="remain-time"></span>
         <i class="bi bi-question-circle ms-auto" data-bs-toggle="tooltip"
            title="추세·변동성·거래량·체결강도·골든크로스·RSI를 조합해 매수 우선순위를 한눈에 보여줍니다."></i>
         <i class="ms-2 bi bi-arrow-clockwise" role="button" data-refresh="signals"


### PR DESCRIPTION
## Summary
- log indicator values during buy signal calculation
- retry indicator calculation when data is missing
- refresh market and signal data on each 5m candle close
- show remaining refresh time in dashboard headers
- update JS to poll data every five minutes

## Testing
- `pytest -q` *(fails: command not found)*