### PR TITLE
Align dashboard timers with candle updates

### DIFF
--- a/static/js/main.js
+++ b/static/js/main.js
@@ -410,6 +410,12 @@ async function loadStatus(){
           btn.textContent = '봇 시작';
         }
       }
+      if (data.status.next_refresh) {
+        const next = new Date(data.status.next_refresh).getTime();
+        const remain = Math.max(0, Math.ceil((next - Date.now()) / 1000));
+        balRemain = remain;
+        sigRemain = remain;
+      }
       disconnected = false;
     } else if (data.message) {
       showAlert(data.message, '에러');
@@ -443,6 +449,7 @@ async function reloadAccount(){
   }
 }
 
+const STATUS_INT = 300000;  // 5분
 const BAL_INT = 300000;  // 5분
 const SIG_INT = 300000;
 let balRemain = BAL_INT / 1000;
@@ -457,13 +464,13 @@ function updateRemain(id, sec){
 }
 
 document.addEventListener('DOMContentLoaded', ()=>{
-  setInterval(loadStatus, 5000);
+  setInterval(loadStatus, STATUS_INT);
   setInterval(reloadAccount, 10000);
-  setInterval(()=>{ reloadBalance(); balRemain = BAL_INT/1000; }, BAL_INT);
-  setInterval(()=>{ reloadBuyMonitor(); sigRemain = SIG_INT/1000; }, SIG_INT);
+  setInterval(async ()=>{ await reloadBalance(); await loadStatus(); }, BAL_INT);
+  setInterval(async ()=>{ await reloadBuyMonitor(); await loadStatus(); }, SIG_INT);
   setInterval(()=>{ if(balRemain>0) balRemain--; updateRemain('balanceTimer', balRemain); },1000);
   setInterval(()=>{ if(sigRemain>0) sigRemain--; updateRemain('signalTimer', sigRemain); },1000);
-  loadStatus();
+  setTimeout(loadStatus, 3000);
   reloadAccount();
   reloadBalance();
   reloadBuyMonitor();


### PR DESCRIPTION
## Summary
- track the next refresh time using `next_refresh`
- retry market data fetches if empty
- retry buy signal calc quickly
- sync `balRemain` and `sigRemain` with `next_refresh`

## Testing
- `pytest -q` *(fails: command not found)*