### PR TITLE
Redesign alert modal

### DIFF
--- a/static/css/custom.css
+++ b/static/css/custom.css
@@ -142,3 +142,32 @@ input[type="password"] { letter-spacing:0.2em; }
   font-size: 0.9rem;
   color: #fff;
 }
+
+/* Redesigned alert modal for better readability */
+#alertModal .modal-dialog {
+  width: 66.7vw;
+  max-width: none;
+}
+#alertModal .modal-content {
+  height: 37.5vh;
+  display: flex;
+  flex-direction: column;
+  justify-content: center;
+  text-align: center;
+  border-radius: 1rem;
+}
+#alertModal .modal-title {
+  font-size: 2rem;
+  font-weight: 600;
+}
+#alertModal .modal-body {
+  flex: 1;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  font-size: 1.25rem;
+}
+#alertModal .btn {
+  font-size: 1.2rem;
+  padding: 0.6rem 1.2rem;
+}

--- a/templates/base.html
+++ b/templates/base.html
@@ -32,7 +32,7 @@
         <h5 class="modal-title">알림</h5>
         <button type="button" class="btn-close btn-close-white" data-bs-dismiss="modal"></button>
       </div>
-      <div class="modal-body">여기에 메시지가 표시됩니다.</div>
+      <div class="modal-body">알림 내용을 확인해 주세요. 이곳에 상세한 안내가 표시됩니다.</div>
       <div class="modal-footer">
         <button type="button" class="btn btn-primary w-100" data-bs-dismiss="modal">확인</button>
       </div>


### PR DESCRIPTION
## Summary
- redesign the popup alert to use 16:9 ratio and fill about a quarter of the screen
- update default alert text for clarity

## Testing
- `pytest -q` *(fails: command not found)*