### PR TITLE
Fix inline style comment

### DIFF
--- a/templates/index.html
+++ b/templates/index.html
@@ -131,6 +131,7 @@
                     <span class="dot entry" data-pos="{{ p.entry_pct }}"></span>
                     <span class="dot take"></span>
                     {% if p.pin_pct is not none %}
+                      <!-- Jinja2 변수 사용 시 세미콜론 필요 -->
                       <span class="pin" style="left: {{ p.pin_pct }}%;"></span>
                     {% endif %}
                   </div>


### PR DESCRIPTION
## Summary
- add a note in the template reminding that the inline style needs a semicolon

## Testing
- `python -m pytest -q` *(fails: No module named pytest)*