### PR TITLE
Fix Buy Monitoring table height

### DIFF
--- a/templates/index.html
+++ b/templates/index.html
@@ -162,7 +162,7 @@
         <i class="ms-2 bi bi-arrow-clockwise" role="button" data-refresh="signals"
            data-bs-toggle="tooltip" title="데이터 새로 고침"></i>
       </div>
-      <div class="table-responsive no-scroll">
+      <div class="table-responsive">
         <table class="table table-bordered text-center mb-0">
           <thead class="table-light"><tr>
             <th>코인</th><th>현재가</th>


### PR DESCRIPTION
## Summary
- allow scrolling in the Buy Monitoring table when rows exceed available space

## Testing
- `pytest -q` *(fails: command not found)*