### PR TITLE
Implement local countdown reset

### DIFF
--- a/README.md
+++ b/README.md
@@ -84,10 +84,10 @@ indicator value calculated for buy signals. The dashboard headers display the
 remaining time until the next account and signal refresh, updated when a new
 5‑minute candle closes.
 
-When the countdown reaches `0:00` the client polls `/api/status` again as soon
-as the server refreshes market data. The returned `next_refresh` value matches
-the close time of the next five‑minute candle so the timer immediately starts
-counting down toward the following update.
+When the countdown reaches `0:00` it now resets to `5:00` on the browser and
+continues decreasing every second. Once the server finishes processing and
+`/api/status` returns a new `next_refresh` value, the timer is synchronised with
+the actual remaining time until the next five‑minute candle closes.
 
 Both monitoring tables are refreshed right after each calculation. The
 background loops emit a `refresh_data` SocketIO event, which triggers the

--- a/static/js/main.js
+++ b/static/js/main.js
@@ -461,8 +461,9 @@ async function reloadAccount(){
 const STATUS_INT = 300000;  // 5분
 const BAL_INT = 300000;  // 5분
 const SIG_INT = 300000;
-let balRemain = BAL_INT / 1000;
-let sigRemain = SIG_INT / 1000;
+const REFRESH_SEC = BAL_INT / 1000;
+let balRemain = REFRESH_SEC;
+let sigRemain = REFRESH_SEC;
 
 function updateRemain(id, sec){
   const el = document.getElementById(id);
@@ -477,8 +478,14 @@ document.addEventListener('DOMContentLoaded', ()=>{
   setInterval(reloadAccount, 10000);
   setInterval(async ()=>{ await reloadBalance(); await loadStatus(); }, BAL_INT);
   setInterval(async ()=>{ await reloadBuyMonitor(); await loadStatus(); }, SIG_INT);
-  setInterval(()=>{ if(balRemain>0) balRemain--; updateRemain('balanceTimer', balRemain); },1000);
-  setInterval(()=>{ if(sigRemain>0) sigRemain--; updateRemain('signalTimer', sigRemain); },1000);
+  setInterval(()=>{
+    balRemain = balRemain > 0 ? balRemain - 1 : REFRESH_SEC;
+    updateRemain('balanceTimer', balRemain);
+  },1000);
+  setInterval(()=>{
+    sigRemain = sigRemain > 0 ? sigRemain - 1 : REFRESH_SEC;
+    updateRemain('signalTimer', sigRemain);
+  },1000);
   setTimeout(loadStatus, 3000);
   reloadAccount();
   reloadBalance();


### PR DESCRIPTION
## Summary
- start countdown from 5:00 when it reaches 0
- document automatic reset behavior in README

## Testing
- `pytest -q` *(fails: command not found)*