### PR TITLE
Introduce CAL log level and split log files

### DIFF
--- a/README.md
+++ b/README.md
@@ -79,7 +79,8 @@ time changes it refreshes KRW market data using `pyupbit`. Coins are ranked by
 trading.
 
 ## Logging and refresh timers
-Debug logs are written to `debug.log`. Set `LOG_LEVEL=DEBUG` to record each
+Each log level is written to a separate file under the `logs/` directory
+(e.g. `logs/debug.log`, `logs/cal.log`). Set `LOG_LEVEL=DEBUG` to record each
 indicator value calculated for buy signals. The dashboard headers display the
 remaining time until the next account and signal refresh, updated when a new
 5‑minute candle closes.

--- a/app.py
+++ b/app.py
@@ -22,7 +22,7 @@ app = Flask(__name__)  # Flask 애플리케이션 생성
 socketio = SocketIO(app, cors_allowed_origins="*")  # 실시간 알림용 SocketIO
 
 # 로그 설정 (파일 + 콘솔)
-logger = setup_logging(level="DEBUG", log_file="debug.log")
+logger = setup_logging(level="DEBUG", log_dir="logs")
 
 # 숫자 천 단위 콤마 필터
 @app.template_filter('comma')
@@ -285,7 +285,7 @@ def refresh_market_data_retry(retries: int = 3, delay: float = 0.2) -> None:
 
 def calc_buy_signal(ticker: str, coin: str) -> dict:
     """매수 모니터링 지표를 계산해 반환한다."""
-    logger.debug("[BUY MON] calc_buy_signal for %s", ticker)
+    logger.cal("[BUY MON] calc_buy_signal for %s", ticker)
     entry = {
         "coin": coin,
         "price": "⛔",
@@ -358,7 +358,7 @@ def calc_buy_signal(ticker: str, coin: str) -> dict:
             else:
                 entry["strength"] = f"🔻 {tis:.0f}"
         else:
-            logger.debug("[BUY MON] TIS not available for %s", ticker)
+            logger.cal("[BUY MON] TIS not available for %s", ticker)
 
         gc = (ema5.shift(1) < ema20.shift(1)) & (ema5 > ema20)
         dc = (ema5.shift(1) > ema20.shift(1)) & (ema5 < ema20)
@@ -404,7 +404,7 @@ def calc_buy_signal(ticker: str, coin: str) -> dict:
             entry["signal"] = "관망"
             entry["signal_class"] = "wait"
 
-        logger.debug(
+        logger.cal(
             "[BUY MON] %s price=%s trend=%s atr=%.2f vol=%.2f tis=%s gc=%s rsi=%.2f signal=%s",
             ticker,
             entry["price"],
@@ -452,9 +452,9 @@ def calc_buy_signal_retry(ticker: str, coin: str, retries: int = 3) -> dict:
         ]
         if not missing:
             return entry
-        logger.debug("[BUY MON] retry %d for %s missing %s", i + 1, ticker, missing)
+        logger.cal("[BUY MON] retry %d for %s missing %s", i + 1, ticker, missing)
         time.sleep(0.2)
-    logger.debug("[BUY MON] final entry for %s after retries", ticker)
+    logger.cal("[BUY MON] final entry for %s after retries", ticker)
     return entry
 
 
@@ -532,7 +532,7 @@ def buy_signal_monitor_loop() -> None:
 def get_filtered_signals():
     """가격 범위와 거래대금 순위로 필터링한 시세 데이터를 반환한다."""
     logger.info("[MONITOR] 매수 모니터링 요청")
-    logger.debug("[MONITOR] 필터 조건 %s", filter_config)
+    logger.cal("[MONITOR] 필터 조건 %s", filter_config)
     min_p = float(filter_config.get("min_price", 0) or 0)
     max_p = float(filter_config.get("max_price", 0) or 0)
     rank = int(filter_config.get("rank", 0) or 0)
@@ -541,10 +541,10 @@ def get_filtered_signals():
 
     filtered = []
     for s in data:
-        logger.debug("[MONITOR] 원본 시그널 %s", s)
+        logger.cal("[MONITOR] 원본 시그널 %s", s)
         price = s["price"]
         if min_p and price < min_p:
-            logger.debug(
+            logger.cal(
                 "[MONITOR] 제외 %s price %.8f < min_price %.8f",
                 s["coin"],
                 price,
@@ -552,7 +552,7 @@ def get_filtered_signals():
             )
             continue
         if max_p and max_p > 0 and price > max_p:
-            logger.debug(
+            logger.cal(
                 "[MONITOR] 제외 %s price %.8f > max_price %.8f",
                 s["coin"],
                 price,
@@ -567,7 +567,7 @@ def get_filtered_signals():
     result = []
     for s in filtered:
         entry = {k: v for k, v in s.items() if k != "rank"}
-        logger.debug(
+        logger.cal(
             "[MONITOR] 선정 %s price %.8f rank %d",
             entry["coin"],
             s["price"],
@@ -577,15 +577,15 @@ def get_filtered_signals():
 
     logger.info("[MONITOR] UPBIT 응답 %d개", len(result))
     for s in result:
-        logger.debug("[MONITOR] 응답 데이터 %s", s)
+        logger.cal("[MONITOR] 응답 데이터 %s", s)
     return result
 
 def get_filtered_tickers() -> list[str]:
     """대시보드 조건에 맞는 KRW 티커 목록을 반환한다."""
-    logger.debug("Filtering tickers with %s", filter_config)
+    logger.cal("Filtering tickers with %s", filter_config)
     signals = get_filtered_signals()
     tickers = [f"KRW-{s['coin']}" for s in signals]
-    logger.debug("Filtered tickers: %s", tickers)
+    logger.cal("Filtered tickers: %s", tickers)
     return tickers
 
 

--- a/bot/indicators.py
+++ b/bot/indicators.py
@@ -14,7 +14,7 @@ def calc_indicators(df):
     입력: df - OHLCV 데이터프레임 (컬럼명: open/high/low/close/volume)
     출력: df - 지표 컬럼 추가 후 반환
     """
-    logger.debug("calc_indicators called")
+    logger.cal("calc_indicators called")
     # 이동평균선(EMA) 계산 - 모든 컬럼명은 소문자
     df['ema5'] = ta.EMA(df['close'], 5)
     df['ema20'] = ta.EMA(df['close'], 20)
@@ -38,5 +38,5 @@ def calc_indicators(df):
     df.bfill(inplace=True)
     df.fillna(0, inplace=True)
     if not df.empty:
-        logger.debug("Indicators calculated: %s", df.iloc[-1].to_dict())
+        logger.cal("Indicators calculated: %s", df.iloc[-1].to_dict())
     return df  # 지표가 추가된 데이터프레임 반환

--- a/bot/strategy.py
+++ b/bot/strategy.py
@@ -14,7 +14,7 @@ def m_break(df, tis, params):
     ema5 > ema20 > ema60, ATR ≥ 0.035,
     20봉 평균 거래량의 1.8배 폭증, 체결강도 120+, 전고점 0.15% 돌파
     """
-    logger.debug("m_break evaluation")
+    logger.cal("m_break evaluation")
     # 최근 1봉 데이터
     last = df.iloc[-1]  # 현재 봉
     # 이전 20봉 동안의 최고가(돌파 기준선)
@@ -26,7 +26,7 @@ def m_break(df, tis, params):
         tis >= 120 and                                # 체결강도 120 이상
         last['close'] > prev_high * 1.0015             # 전고 돌파
     )
-    logger.debug(
+    logger.cal(
         "m_break close=%s prev_high=%s volume=%s atr=%s tis=%s -> %s",
         last['close'],
         prev_high,
@@ -42,7 +42,7 @@ def p_pull(df, tis, params):
     P-PULL (눌림목 반등)
     ema5 > ema20 > ema60, ema50 근접(0.3% 이내), rsi ≤ 28, 거래량 증가
     """
-    logger.debug("p_pull evaluation")
+    logger.cal("p_pull evaluation")
     last = df.iloc[-1]  # 현재 봉 데이터
     ema50 = df['ema50'].iloc[-1]
     ok = (
@@ -51,7 +51,7 @@ def p_pull(df, tis, params):
         last['rsi'] <= params.get('rsi', 28) and
         last['volume'] >= df['volume'].iloc[-2] * 1.2
     )
-    logger.debug(
+    logger.cal(
         "p_pull close=%s ema50=%s rsi=%s volume=%s -> %s",
         last['close'],
         ema50,
@@ -66,7 +66,7 @@ def t_flow(df, tis, params):
     T-FLOW (중기 추세+OBV)
     ema20 기울기 0.15%↑, obv 3봉 연속 상승, rsi 48~60
     """
-    logger.debug("t_flow evaluation")
+    logger.cal("t_flow evaluation")
     # EMA20 최근 5봉 기울기 계산
     ema20_slope = (df['ema20'].iloc[-1] - df['ema20'].iloc[-5]) / (abs(df['ema20'].iloc[-5]) + 1e-9)
     # OBV가 3봉 연속 상승하는지 체크
@@ -75,7 +75,7 @@ def t_flow(df, tis, params):
     ok = (
         ema20_slope > 0.0015 and obv_inc and 48 <= rsi <= 60
     )
-    logger.debug(
+    logger.cal(
         "t_flow slope=%s obv_inc=%s rsi=%s -> %s",
         ema20_slope,
         obv_inc,
@@ -89,7 +89,7 @@ def b_low(df, tis, params):
     B-LOW (박스권 하단 반등)
     80봉 내 박스폭 6% 이내, 저점 터치, rsi < 25
     """
-    logger.debug("b_low evaluation")
+    logger.cal("b_low evaluation")
     # 최근 80봉의 최저·최고가
     low80 = df['low'][-80:].min()
     high80 = df['high'][-80:].max()
@@ -101,7 +101,7 @@ def b_low(df, tis, params):
         last['low'] <= low80 * 1.01 and
         last['rsi'] < params.get('rsi', 25)
     )
-    logger.debug(
+    logger.cal(
         "b_low box_ratio=%s low80=%s rsi=%s -> %s",
         box_ratio,
         low80,
@@ -115,7 +115,7 @@ def v_rev(df, tis, params):
     V-REV (대폭락 후 강한 반등)
     직전봉 -4% 이상 하락, 거래량 2.5배↑, RSI14 18→20 상승, 반등폭 4%↑
     """
-    logger.debug("v_rev evaluation")
+    logger.cal("v_rev evaluation")
     last = df.iloc[-1]   # 현재 봉
     prev = df.iloc[-2]   # 직전 봉
     price_drop = (prev['close'] - last['close']) / (prev['close'] + 1e-9)
@@ -128,7 +128,7 @@ def v_rev(df, tis, params):
         rsi_rise and
         price_rebound
     )
-    logger.debug(
+    logger.cal(
         "v_rev drop=%s vol_burst=%s rsi_rise=%s rebound=%s -> %s",
         price_drop,
         volume_burst,
@@ -143,7 +143,7 @@ def g_rev(df, tis, params):
     G-REV (골든크로스+지지)
     ema50 > ema200 골든, rsi ≥ 48, 거래량 이전봉 대비 0.6배↑
     """
-    logger.debug("g_rev evaluation")
+    logger.cal("g_rev evaluation")
     last = df.iloc[-1]  # 현재 봉 데이터
     golden = last['ema50'] > last['ema200']
     ok = (
@@ -151,7 +151,7 @@ def g_rev(df, tis, params):
         last['rsi'] >= 48 and
         last['volume'] >= df['volume'].iloc[-2] * 0.6
     )
-    logger.debug(
+    logger.cal(
         "g_rev golden=%s rsi=%s volume=%s -> %s",
         golden,
         last['rsi'],
@@ -165,7 +165,7 @@ def vol_brk(df, tis, params):
     VOL-BRK (ATR 폭발·신고가)
     ATR 비율 급등, 거래량 증가, 신고가 돌파, rsi ≥ 60
     """
-    logger.debug("vol_brk evaluation")
+    logger.cal("vol_brk evaluation")
     last = df.iloc[-1]  # 현재 봉
     atr10 = df['atr'][-10:].mean()
     vol20 = df['volume'][-20:].mean()     # 20봉 평균 거래량
@@ -176,7 +176,7 @@ def vol_brk(df, tis, params):
         last['high'] > high20 * 0.999 and
         last['rsi'] >= 60
     )
-    logger.debug(
+    logger.cal(
         "vol_brk atr_ratio=%s vol_ratio=%s high=%s rsi=%s -> %s",
         last['atr'] / (atr10 + 1e-9),
         last['volume'] / (vol20+1e-9),
@@ -191,10 +191,10 @@ def ema_stack(df, tis, params):
     EMA-STACK (다중 EMA + ADX)
     ema25 > ema100 > ema200, adx ≥ 30
     """
-    logger.debug("ema_stack evaluation")
+    logger.cal("ema_stack evaluation")
     last = df.iloc[-1]
     ok = last['ema25'] > last['ema100'] > last['ema200'] and last['adx'] >= 30
-    logger.debug(
+    logger.cal(
         "ema_stack adx=%s -> %s",
         last['adx'],
         ok,
@@ -206,7 +206,7 @@ def vwap_bnc(df, tis, params):
     VWAP-BNC (VWAP/RSI 조합)
     ema5 > ema20 > ema60, vwap 근접, rsi 45~60, 거래량 증가
     """
-    logger.debug("vwap_bnc evaluation")
+    logger.cal("vwap_bnc evaluation")
     last = df.iloc[-1]       # 현재 봉
     vwap = last['vwap']
     vwap_close_ratio = abs(last['close'] - vwap) / (vwap+1e-9)  # 종가와 VWAP 차이
@@ -216,7 +216,7 @@ def vwap_bnc(df, tis, params):
         45 <= last['rsi'] <= 60 and
         last['volume'] >= df['volume'].iloc[-2]
     )
-    logger.debug(
+    logger.cal(
         "vwap_bnc vwap_ratio=%s rsi=%s volume=%s -> %s",
         vwap_close_ratio,
         last['rsi'],
@@ -243,10 +243,10 @@ def select_strategy(strategy_name, df, tis, params):
     전략명/지표/체결강도/파라미터로 전략 함수 실행
     사용 예: ok, param = select_strategy('M-BREAK', df, tis, {...})
     """
-    logger.debug("select_strategy %s", strategy_name)
+    logger.cal("select_strategy %s", strategy_name)
     func = STRATS.get(strategy_name)   # 전략 이름으로 함수 찾기
     if not func:
         return False, {}
     ok, res = func(df, tis, params)
-    logger.debug("%s -> %s", strategy_name, ok)
+    logger.cal("%s -> %s", strategy_name, ok)
     return ok, res

--- a/bot/trader.py
+++ b/bot/trader.py
@@ -105,11 +105,11 @@ class UpbitTrader:
                     df = calc_indicators(df)
                     if self.logger:
                         last = df.iloc[-1].to_dict()
-                        self.logger.debug("Indicators %s", last)
+                        self.logger.cal("Indicators %s", last)
                     tis = calc_tis(ticker) or 0
                     ok, strat_params = select_strategy(strat_name, df, tis, params)
                     if self.logger:
-                        self.logger.debug(
+                        self.logger.cal(
                             "Strategy %s result=%s params=%s",
                             strat_name,
                             ok,
@@ -188,7 +188,7 @@ class UpbitTrader:
                 "pnl": round(pnl, 2),
             }
             if self.logger:
-                self.logger.debug("Account summary %s", summary)
+                self.logger.cal("Account summary %s", summary)
             return summary
         except Exception as e:
             if self.logger:

--- a/utils.py
+++ b/utils.py
@@ -10,7 +10,37 @@ import requests
 import pyupbit
 
 
-def setup_logging(level: str | None = None, log_file: str = "logs/trace.log") -> logging.Logger:
+# Custom log level for detailed calculations
+CAL_LEVEL = 15
+logging.addLevelName(CAL_LEVEL, "CAL")
+
+
+def _cal(self, message, *args, **kwargs) -> None:
+    """Log 'message' with level 'CAL'."""
+    if self.isEnabledFor(CAL_LEVEL):
+        self._log(CAL_LEVEL, message, args, **kwargs)
+
+
+logging.Logger.cal = _cal
+
+
+def cal(message: str, *args, **kwargs) -> None:
+    """Module level CAL log."""
+    logging.log(CAL_LEVEL, message, *args, **kwargs)
+
+
+class LevelFilter(logging.Filter):
+    """Filter to allow only records of a specific level."""
+
+    def __init__(self, level: int) -> None:
+        super().__init__()
+        self.level = level
+
+    def filter(self, record: logging.LogRecord) -> bool:  # type: ignore[override]
+        return record.levelno == self.level
+
+
+def setup_logging(level: str | None = None, log_dir: str = "logs") -> logging.Logger:
     """로그 파일과 콘솔 출력을 설정한다."""
     if level is None:
         level = os.getenv("LOG_LEVEL", "INFO")
@@ -18,18 +48,28 @@ def setup_logging(level: str | None = None, log_file: str = "logs/trace.log") ->
     logger = logging.getLogger()
     logger.setLevel(numeric_level)
     if not logger.handlers:
-        directory = os.path.dirname(log_file)
-        if directory:
-            os.makedirs(directory, exist_ok=True)
+        os.makedirs(log_dir, exist_ok=True)
         fmt = logging.Formatter(
             "[%(levelname)s][%(asctime)s][%(name)s] %(message)s",
             "%Y-%m-%d %H:%M:%S",
         )
-        fh = logging.FileHandler(log_file, encoding="utf-8")
-        fh.setFormatter(fmt)
+        files = [
+            ("debug", logging.DEBUG),
+            ("cal", CAL_LEVEL),
+            ("info", logging.INFO),
+            ("warning", logging.WARNING),
+            ("error", logging.ERROR),
+            ("critical", logging.CRITICAL),
+        ]
+        for name, lvl in files:
+            fh = logging.FileHandler(os.path.join(log_dir, f"{name}.log"), encoding="utf-8")
+            fh.setFormatter(fmt)
+            fh.setLevel(lvl)
+            fh.addFilter(LevelFilter(lvl))
+            logger.addHandler(fh)
         sh = logging.StreamHandler()
         sh.setFormatter(fmt)
-        logger.addHandler(fh)
+        sh.setLevel(logging.INFO)
         logger.addHandler(sh)
     return logger
 
@@ -113,45 +153,45 @@ def calc_tis(ticker: str, minutes: int = 5, count: int = 200) -> float | None:
     ``count`` 는 업비트에서 가져올 틱 데이터 개수(최대 200)를 지정한다.
     API 요청에 실패하면 ``None`` 을 반환한다.
     """
-    logging.debug("calc_tis start for %s", ticker)
+    cal("calc_tis start for %s", ticker)
     try:
         if hasattr(pyupbit, "get_ticks"):
             ticks = pyupbit.get_ticks(ticker, count=count)
         else:
             ticks = _fetch_ticks(ticker, count)
         if not ticks:
-            logging.debug("calc_tis no tick data for %s", ticker)
+            cal("calc_tis no tick data for %s", ticker)
             raise ValueError("no ticks")
         df = pd.DataFrame(ticks)
         cutoff = int((time.time() - minutes * 60) * 1000)
         recent = df[df["timestamp"] >= cutoff]
         if recent.empty:
-            logging.debug("calc_tis no recent ticks for %s", ticker)
+            cal("calc_tis no recent ticks for %s", ticker)
         buy_qty = recent[recent["ask_bid"] == "BID"]["trade_volume"].sum()
         sell_qty = recent[recent["ask_bid"] == "ASK"]["trade_volume"].sum()
         tis = (buy_qty / sell_qty) * 100 if sell_qty > 0 else 0.0
-        logging.debug("[TIS] %s buy=%.2f sell=%.2f tis=%.2f", ticker, buy_qty, sell_qty, tis)
+        cal("[TIS] %s buy=%.2f sell=%.2f tis=%.2f", ticker, buy_qty, sell_qty, tis)
         if ticker.endswith("-XPR"):
             logging.info("[TIS] XPR buy=%.2f sell=%.2f tis=%.2f", buy_qty, sell_qty, tis)
         return tis
     except Exception as e:  # API or parsing error
-        logging.debug("calc_tis failed for %s: %s", ticker, e)
+        cal("calc_tis failed for %s: %s", ticker, e)
         try:
             ob = pyupbit.get_orderbook(ticker)
             if not ob:
-                logging.debug("calc_tis no orderbook for %s", ticker)
+                cal("calc_tis no orderbook for %s", ticker)
                 return None
             book = ob[0]
             bid = float(book.get("total_bid_size", 0))
             ask = float(book.get("total_ask_size", 0))
             if ask == 0:
-                logging.debug("calc_tis ask size zero for %s", ticker)
+                cal("calc_tis ask size zero for %s", ticker)
                 return None
             tis = (bid / ask) * 100
-            logging.debug("[TIS-FB] %s orderbook tis=%.2f", ticker, tis)
+            cal("[TIS-FB] %s orderbook tis=%.2f", ticker, tis)
             return tis
         except Exception as e2:
-            logging.debug("calc_tis fallback failed for %s: %s", ticker, e2)
+            cal("calc_tis fallback failed for %s: %s", ticker, e2)
             return None
 
 


### PR DESCRIPTION
## Summary
- implement custom `CAL` log level for algorithm calculations
- write each log level to separate files under `logs/`
- adjust console logging to INFO
- update strategy and indicator modules to use the new level
- document logging changes in README

## Testing
- `pytest -q` *(fails: command not found)*