### PR TITLE
Add monitoring dashboard and trade logger

### DIFF
--- a/helpers/logger.py
+++ b/helpers/logger.py
@@ -1,0 +1,41 @@
+# -*- coding: utf-8 -*-
+"""트레이드 및 이벤트 로그 기록 모듈."""
+
+from __future__ import annotations
+
+import csv
+import os
+from collections import deque
+from datetime import datetime
+from typing import Any, Dict
+
+# 최근 n건 로그를 메모리에 보관한다
+_recent_logs: deque[dict] = deque(maxlen=100)
+
+
+def _write_csv(path: str, row: Dict[str, Any]) -> None:
+    """단일 로그를 CSV 파일로 저장한다."""
+    os.makedirs(os.path.dirname(path), exist_ok=True)
+    write_header = not os.path.exists(path)
+    with open(path, "a", newline="", encoding="utf-8") as f:
+        writer = csv.DictWriter(f, fieldnames=row.keys())
+        if write_header:
+            writer.writeheader()
+        writer.writerow(row)
+
+
+def log_trade(event_type: str, data: Dict[str, Any], path: str = "logs/trade_history.csv") -> None:
+    """이벤트 유형과 데이터를 받아 로그를 남긴다."""
+    entry = {"time": datetime.now().strftime("%Y-%m-%d %H:%M:%S"), "type": event_type}
+    entry.update(data)
+    _recent_logs.appendleft(entry)
+    try:
+        _write_csv(path, entry)
+    except Exception:
+        pass
+
+
+def get_recent_logs(limit: int = 20) -> list[dict]:
+    """최근 ``limit``개 로그를 반환한다."""
+    return list(_recent_logs)[:limit]
+

--- a/static/js/dashboard.js
+++ b/static/js/dashboard.js
@@ -1,0 +1,48 @@
+// static/js/dashboard.js
+// 대시보드 실시간 로그 테이블 관리
+
+let logList = [];
+
+function updateLogTable(list){
+  const body = document.getElementById('logBody');
+  if(!body) return;
+  if(!list.length){
+    body.innerHTML = '<tr><td colspan="6" class="text-muted py-3">없음</td></tr>';
+    return;
+  }
+  body.innerHTML = list.map(l => `
+    <tr>
+      <td>${l.time}</td>
+      <td>${l.type}</td>
+      <td>${l.action || ''}</td>
+      <td>${l.coin || ''}</td>
+      <td>${l.price !== undefined ? formatNumber(l.price) : ''}</td>
+      <td>${l.amount !== undefined ? formatNumber(l.amount) : ''}</td>
+    </tr>
+  `).join('');
+}
+
+async function loadLogs(){
+  try{
+    const data = await fetchJsonRetry('/api/logs');
+    if(data && data.result === 'success'){
+      logList = data.logs;
+      updateLogTable(logList);
+    }
+  }catch(err){
+    console.error('loadLogs failed', err);
+  }
+}
+
+document.addEventListener('DOMContentLoaded', ()=>{
+  loadLogs();
+  if(window.io){
+    const sock = io();
+    sock.on('log', log => {
+      logList.unshift(log);
+      logList = logList.slice(0,20);
+      updateLogTable(logList);
+    });
+  }
+});
+

--- a/templates/base.html
+++ b/templates/base.html
@@ -17,6 +17,7 @@
   <div class="collapse navbar-collapse ms-4" id="navbarNav">
     <ul class="navbar-nav">
       <li class="nav-item"><a class="nav-link {% if request.path == '/' %}active{% endif %}" href="/">대시보드</a></li>
+      <li class="nav-item"><a class="nav-link {% if '/dashboard' in request.path %}active{% endif %}" href="/dashboard">모니터</a></li>
       <li class="nav-item"><a class="nav-link {% if '/strategy' in request.path %}active{% endif %}" href="/strategy">매매설정</a></li>
       <li class="nav-item"><a class="nav-link {% if '/ai-analysis' in request.path %}active{% endif %}" href="/ai-analysis">AI전략분석</a></li>
       <li class="nav-item"><a class="nav-link {% if '/risk' in request.path %}active{% endif %}" href="/risk">리스크관리</a></li>

--- a/templates/dashboard.html
+++ b/templates/dashboard.html
@@ -1,0 +1,21 @@
+{% extends 'base.html' %}
+{% block title %}실시간 모니터링{% endblock %}
+{% block content %}
+<div class="container py-4">
+  <h2 class="mb-4">자동매매 대시보드</h2>
+  <div class="card">
+    <div class="card-head">실시간 로그</div>
+    <div class="card-body">
+      <table class="table table-bordered text-center">
+        <thead class="table-light">
+          <tr><th>시간</th><th>종류</th><th>액션</th><th>코인</th><th>가격</th><th>금액</th></tr>
+        </thead>
+        <tbody id="logBody">
+          <tr><td colspan="6" class="text-muted py-3">로그 대기중...</td></tr>
+        </tbody>
+      </table>
+    </div>
+  </div>
+</div>
+<script src="/static/js/dashboard.js"></script>
+{% endblock %}

--- a/tests/test_logger.py
+++ b/tests/test_logger.py
@@ -1,0 +1,11 @@
+from helpers.logger import log_trade, get_recent_logs
+import os
+
+
+def test_log_trade(tmp_path):
+    path = tmp_path / "log.csv"
+    log_trade("trade", {"action": "buy", "coin": "BTC", "price": 1}, path=str(path))
+    logs = get_recent_logs(1)
+    assert logs[0]["action"] == "buy"
+    assert path.exists()
+


### PR DESCRIPTION
## Summary
- implement `helpers.logger` for trade/event logging
- create `/dashboard` route with new template and JS
- emit logs from manual trading and bot control actions
- expose logs via `/api/logs`
- add basic test for logger

## Testing
- `pytest -q` *(fails: command not found)*