### PR TITLE
Add validation for settings

### DIFF
--- a/helpers/utils/funds.py
+++ b/helpers/utils/funds.py
@@ -1,6 +1,22 @@
 import os
 import json
 
+
+def _validate(data: dict) -> None:
+    """숫자 범위와 타입을 확인한다."""
+    max_invest = float(data.get("max_invest_per_coin", 0))
+    buy_amt = float(data.get("buy_amount", 0))
+    max_trades = int(data.get("max_concurrent_trades", 1))
+    slippage = float(data.get("slippage_tolerance", 0))
+    if max_invest < 0 or max_invest > 1_000_000_000:
+        raise ValueError("max_invest_per_coin out of range")
+    if buy_amt < 0 or buy_amt > 1_000_000_000:
+        raise ValueError("buy_amount out of range")
+    if max_trades < 1 or max_trades > 100:
+        raise ValueError("max_concurrent_trades out of range")
+    if slippage < 0 or slippage > 1:
+        raise ValueError("slippage_tolerance out of range")
+
 def load_fund_settings(path: str = "config/funds.json") -> dict:
     """자금 설정 파일을 읽어 반환한다."""
     if not os.path.exists(path):
@@ -17,6 +33,7 @@ def load_fund_settings(path: str = "config/funds.json") -> dict:
 
 def save_fund_settings(data: dict, path: str = "config/funds.json") -> None:
     """자금 설정을 저장하고 업데이트 시각을 기록한다."""
+    _validate(data)
     data["updated"] = __import__("datetime").datetime.now().isoformat(timespec="seconds")
     with open(path, "w", encoding="utf-8") as f:
         json.dump(data, f, ensure_ascii=False, indent=2)

--- a/helpers/utils/risk.py
+++ b/helpers/utils/risk.py
@@ -2,6 +2,13 @@ import json
 import os
 
 
+def _validate(data: dict) -> None:
+    """숫자 값이 허용 범위인지 확인한다."""
+    max_dd = float(data.get("max_dd_per_coin", 0))
+    if max_dd < 0 or max_dd > 1:
+        raise ValueError("max_dd_per_coin out of range")
+
+
 def load_risk_settings(path: str = "config/risk.json") -> dict:
     """리스크 관리 설정을 읽어 기본값을 제공한다."""
     if not os.path.exists(path):
@@ -12,6 +19,7 @@ def load_risk_settings(path: str = "config/risk.json") -> dict:
 
 def save_risk_settings(data: dict, path: str = "config/risk.json") -> None:
     """리스크 관리 설정을 저장한다."""
+    _validate(data)
     with open(path, "w", encoding="utf-8") as f:
         json.dump(data, f, ensure_ascii=False, indent=2)
 

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -21,6 +21,8 @@ if 'pyupbit' not in sys.modules:
 
 import utils
 from helpers.utils.funds import load_fund_settings, save_fund_settings
+from helpers.utils.risk import save_risk_settings
+import pytest
 
 
 def test_calc_tis_fallback():
@@ -54,4 +56,18 @@ def test_fund_settings_io(tmp_path):
     assert loaded["max_invest_per_coin"] == 1000
     assert loaded["buy_amount"] == 200
     assert "updated" in loaded
+
+
+def test_fund_settings_validation(tmp_path):
+    path = tmp_path / "f.json"
+    data = {"max_invest_per_coin": -1, "buy_amount": 1, "max_concurrent_trades": 1,
+            "slippage_tolerance": 0.1, "balance_exhausted_action": "알림"}
+    with pytest.raises(ValueError):
+        save_fund_settings(data, str(path))
+
+
+def test_risk_settings_validation(tmp_path):
+    path = tmp_path / "r.json"
+    with pytest.raises(ValueError):
+        save_risk_settings({"max_dd_per_coin": -0.1}, str(path))
 


### PR DESCRIPTION
## Summary
- validate fund settings before save
- validate risk settings before save
- test validation logic

## Testing
- `python -m pytest -q` *(fails: No module named pytest)*