### PR TITLE
Add strategy restore defaults

### DIFF
--- a/config/default_strategy.json
+++ b/config/default_strategy.json
@@ -1,0 +1,178 @@
+[
+  {
+    "active": false,
+    "name": "M-BREAK",
+    "buy_condition": "중도적",
+    "sell_condition": "중도적",
+    "priority": 1
+  },
+  {
+    "active": false,
+    "name": "VOL-BRK",
+    "buy_condition": "중도적",
+    "sell_condition": "중도적",
+    "priority": 2
+  },
+  {
+    "active": false,
+    "name": "RSI-PULL",
+    "buy_condition": "중도적",
+    "sell_condition": "중도적",
+    "priority": 3
+  },
+  {
+    "active": false,
+    "name": "ADX-TREND",
+    "buy_condition": "중도적",
+    "sell_condition": "중도적",
+    "priority": 4
+  },
+  {
+    "active": false,
+    "name": "MA-CROSS",
+    "buy_condition": "중도적",
+    "sell_condition": "중도적",
+    "priority": 5
+  },
+  {
+    "active": false,
+    "name": "Boll-BB",
+    "buy_condition": "중도적",
+    "sell_condition": "중도적",
+    "priority": 6
+  },
+  {
+    "active": false,
+    "name": "KDJ-OSC",
+    "buy_condition": "중도적",
+    "sell_condition": "중도적",
+    "priority": 7
+  },
+  {
+    "active": false,
+    "name": "MACD-BOOST",
+    "buy_condition": "중도적",
+    "sell_condition": "중도적",
+    "priority": 8
+  },
+  {
+    "active": false,
+    "name": "CCI-REV",
+    "buy_condition": "중도적",
+    "sell_condition": "중도적",
+    "priority": 9
+  },
+  {
+    "active": false,
+    "name": "OBV-PEAK",
+    "buy_condition": "중도적",
+    "sell_condition": "중도적",
+    "priority": 10
+  },
+  {
+    "active": false,
+    "name": "TEMA-PUMP",
+    "buy_condition": "중도적",
+    "sell_condition": "중도적",
+    "priority": 11
+  },
+  {
+    "active": false,
+    "name": "Ichimoku",
+    "buy_condition": "중도적",
+    "sell_condition": "중도적",
+    "priority": 12
+  },
+  {
+    "active": false,
+    "name": "SAR-SWING",
+    "buy_condition": "중도적",
+    "sell_condition": "중도적",
+    "priority": 13
+  },
+  {
+    "active": false,
+    "name": "FIBO-PIVOT",
+    "buy_condition": "중도적",
+    "sell_condition": "중도적",
+    "priority": 14
+  },
+  {
+    "active": false,
+    "name": "HTF-ALIGN",
+    "buy_condition": "중도적",
+    "sell_condition": "중도적",
+    "priority": 15
+  },
+  {
+    "active": false,
+    "name": "VWAP-EDGE",
+    "buy_condition": "중도적",
+    "sell_condition": "중도적",
+    "priority": 16
+  },
+  {
+    "active": false,
+    "name": "ROC-MOM",
+    "buy_condition": "중도적",
+    "sell_condition": "중도적",
+    "priority": 17
+  },
+  {
+    "active": false,
+    "name": "ATR-STOP",
+    "buy_condition": "중도적",
+    "sell_condition": "중도적",
+    "priority": 18
+  },
+  {
+    "active": false,
+    "name": "STOCH-RDY",
+    "buy_condition": "중도적",
+    "sell_condition": "중도적",
+    "priority": 19
+  },
+  {
+    "active": false,
+    "name": "KD-RANGE",
+    "buy_condition": "중도적",
+    "sell_condition": "중도적",
+    "priority": 20
+  },
+  {
+    "active": false,
+    "name": "PSAR-TRAIL",
+    "buy_condition": "중도적",
+    "sell_condition": "중도적",
+    "priority": 21
+  },
+  {
+    "active": false,
+    "name": "BB-BREAK",
+    "buy_condition": "중도적",
+    "sell_condition": "중도적",
+    "priority": 22
+  },
+  {
+    "active": false,
+    "name": "VOL-EXP",
+    "buy_condition": "중도적",
+    "sell_condition": "중도적",
+    "priority": 23
+  },
+  {
+    "active": false,
+    "name": "ADX-DM",
+    "buy_condition": "중도적",
+    "sell_condition": "중도적",
+    "priority": 24
+  },
+  {
+    "active": false,
+    "name": "RSI-BIAS",
+    "buy_condition": "중도적",
+    "sell_condition": "중도적",
+    "priority": 25
+  }
+]
+

--- a/config/strategy.json
+++ b/config/strategy.json
@@ -1,0 +1,178 @@
+[
+  {
+    "active": false,
+    "name": "M-BREAK",
+    "buy_condition": "중도적",
+    "sell_condition": "중도적",
+    "priority": 1
+  },
+  {
+    "active": false,
+    "name": "VOL-BRK",
+    "buy_condition": "중도적",
+    "sell_condition": "중도적",
+    "priority": 2
+  },
+  {
+    "active": false,
+    "name": "RSI-PULL",
+    "buy_condition": "중도적",
+    "sell_condition": "중도적",
+    "priority": 3
+  },
+  {
+    "active": false,
+    "name": "ADX-TREND",
+    "buy_condition": "중도적",
+    "sell_condition": "중도적",
+    "priority": 4
+  },
+  {
+    "active": false,
+    "name": "MA-CROSS",
+    "buy_condition": "중도적",
+    "sell_condition": "중도적",
+    "priority": 5
+  },
+  {
+    "active": false,
+    "name": "Boll-BB",
+    "buy_condition": "중도적",
+    "sell_condition": "중도적",
+    "priority": 6
+  },
+  {
+    "active": false,
+    "name": "KDJ-OSC",
+    "buy_condition": "중도적",
+    "sell_condition": "중도적",
+    "priority": 7
+  },
+  {
+    "active": false,
+    "name": "MACD-BOOST",
+    "buy_condition": "중도적",
+    "sell_condition": "중도적",
+    "priority": 8
+  },
+  {
+    "active": false,
+    "name": "CCI-REV",
+    "buy_condition": "중도적",
+    "sell_condition": "중도적",
+    "priority": 9
+  },
+  {
+    "active": false,
+    "name": "OBV-PEAK",
+    "buy_condition": "중도적",
+    "sell_condition": "중도적",
+    "priority": 10
+  },
+  {
+    "active": false,
+    "name": "TEMA-PUMP",
+    "buy_condition": "중도적",
+    "sell_condition": "중도적",
+    "priority": 11
+  },
+  {
+    "active": false,
+    "name": "Ichimoku",
+    "buy_condition": "중도적",
+    "sell_condition": "중도적",
+    "priority": 12
+  },
+  {
+    "active": false,
+    "name": "SAR-SWING",
+    "buy_condition": "중도적",
+    "sell_condition": "중도적",
+    "priority": 13
+  },
+  {
+    "active": false,
+    "name": "FIBO-PIVOT",
+    "buy_condition": "중도적",
+    "sell_condition": "중도적",
+    "priority": 14
+  },
+  {
+    "active": false,
+    "name": "HTF-ALIGN",
+    "buy_condition": "중도적",
+    "sell_condition": "중도적",
+    "priority": 15
+  },
+  {
+    "active": false,
+    "name": "VWAP-EDGE",
+    "buy_condition": "중도적",
+    "sell_condition": "중도적",
+    "priority": 16
+  },
+  {
+    "active": false,
+    "name": "ROC-MOM",
+    "buy_condition": "중도적",
+    "sell_condition": "중도적",
+    "priority": 17
+  },
+  {
+    "active": false,
+    "name": "ATR-STOP",
+    "buy_condition": "중도적",
+    "sell_condition": "중도적",
+    "priority": 18
+  },
+  {
+    "active": false,
+    "name": "STOCH-RDY",
+    "buy_condition": "중도적",
+    "sell_condition": "중도적",
+    "priority": 19
+  },
+  {
+    "active": false,
+    "name": "KD-RANGE",
+    "buy_condition": "중도적",
+    "sell_condition": "중도적",
+    "priority": 20
+  },
+  {
+    "active": false,
+    "name": "PSAR-TRAIL",
+    "buy_condition": "중도적",
+    "sell_condition": "중도적",
+    "priority": 21
+  },
+  {
+    "active": false,
+    "name": "BB-BREAK",
+    "buy_condition": "중도적",
+    "sell_condition": "중도적",
+    "priority": 22
+  },
+  {
+    "active": false,
+    "name": "VOL-EXP",
+    "buy_condition": "중도적",
+    "sell_condition": "중도적",
+    "priority": 23
+  },
+  {
+    "active": false,
+    "name": "ADX-DM",
+    "buy_condition": "중도적",
+    "sell_condition": "중도적",
+    "priority": 24
+  },
+  {
+    "active": false,
+    "name": "RSI-BIAS",
+    "buy_condition": "중도적",
+    "sell_condition": "중도적",
+    "priority": 25
+  }
+]
+

--- a/helpers/utils/strategy_cfg.py
+++ b/helpers/utils/strategy_cfg.py
@@ -1,0 +1,34 @@
+import json
+import os
+import shutil
+from typing import List, Dict
+
+
+STRATEGY_FILE = "config/strategy.json"
+DEFAULT_FILE = "config/default_strategy.json"
+BACKUP_FILE = "config/strategy_backup.json"
+
+
+def load_strategy_list(path: str = STRATEGY_FILE) -> List[Dict]:
+    """전략 설정 리스트를 읽어 반환한다."""
+    target = path if os.path.exists(path) else DEFAULT_FILE
+    with open(target, encoding="utf-8") as f:
+        return json.load(f)
+
+
+def save_strategy_list(data: List[Dict], path: str = STRATEGY_FILE) -> None:
+    """전략 설정 리스트를 저장한다."""
+    os.makedirs(os.path.dirname(path), exist_ok=True)
+    with open(path, "w", encoding="utf-8") as f:
+        json.dump(data, f, ensure_ascii=False, indent=2)
+
+
+def restore_defaults(
+    default_path: str = DEFAULT_FILE,
+    path: str = STRATEGY_FILE,
+    backup_path: str = BACKUP_FILE,
+) -> None:
+    """기본 전략 파일을 복원한다."""
+    if os.path.exists(path) and not os.path.exists(backup_path):
+        shutil.copy2(path, backup_path)
+    shutil.copy2(default_path, path)

--- a/static/js/strategy.js
+++ b/static/js/strategy.js
@@ -1,4 +1,5 @@
-const apiURL = "/api/strategies";         // TODO: 다음 단계에서 구현
+const apiURL = "/api/strategies";
+const restoreURL = "/api/restore-defaults/strategy";
 const tbody  = document.querySelector("#tbl-strategy tbody");
 const tpl    = document.querySelector("#row-tpl");
 const lastSaved = document.getElementById("last-saved");
@@ -59,7 +60,7 @@ document.getElementById("btn-add").onclick = ()=>{
 };
 
 // ────────────────────────────────
-// 4. 저장 (TODO: 백엔드 POST는 다음 단계에서)
+// 4. 저장
 // ────────────────────────────────
 document.getElementById("btn-save").onclick = async ()=>{
   const rows = [...tbody.querySelectorAll("tr")].map(tr=>({
@@ -70,9 +71,27 @@ document.getElementById("btn-save").onclick = async ()=>{
     priority      : +tr.querySelector(".priority").value || 99,
     updated       : new Date().toISOString()
   }));
-  console.log("★ 저장 payload", rows);
-  // TODO: fetch(apiURL,{method:"POST",headers:{...},body:JSON.stringify(rows)})
-  alert("로컬 미리보기용 — POST 로직은 다음 단계에서 연결합니다.");
+  const res = await fetch(apiURL,{method:"POST",headers:{"Content-Type":"application/json"},body:JSON.stringify(rows)});
+  if(res.ok){
+    showAlert("저장되었습니다.");
+    dispatchUpdated(rows);
+    lastSaved.textContent = new Date().toLocaleString();
+  }else{
+    showAlert("저장 실패","에러");
+  }
+};
+
+document.getElementById("btn-restore").onclick = async ()=>{
+  const ok = await showConfirm("정말 복원하시겠습니까?");
+  if(!ok) return;
+  const res = await fetch(restoreURL,{method:"POST"});
+  if(res.ok){
+    const list = await fetch(apiURL).then(r=>r.json());
+    renderTable(list);
+    showAlert("복원 완료");
+  }else{
+    showAlert("복원 실패","에러");
+  }
 };
 
 // ────────────────────────────────

--- a/templates/strategy.html
+++ b/templates/strategy.html
@@ -3,9 +3,14 @@
 <div class="container my-4">
   <div class="d-flex justify-content-between align-items-center">
     <h2 class="fw-bold"><i class="bi bi-kanban-fill me-2"></i>전략 설정</h2>
-    <button id="btn-save" class="btn btn-primary">
-      <i class="bi bi-save me-1"></i>저장
-    </button>
+    <div class="btn-group">
+      <button id="btn-restore" class="btn btn-outline-secondary">
+        <i class="bi bi-arrow-counterclockwise me-1"></i>기본값 복원
+      </button>
+      <button id="btn-save" class="btn btn-primary">
+        <i class="bi bi-save me-1"></i>저장
+      </button>
+    </div>
   </div>
   <p class="text-muted mt-1">마지막 저장: <span id="last-saved">—</span></p>
 

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -1,5 +1,6 @@
 import sys
 import types
+import json
 from unittest.mock import patch
 
 # 의존 모듈이 없을 때를 대비해 간단한 더미 모듈을 등록한다.
@@ -70,4 +71,23 @@ def test_risk_settings_validation(tmp_path):
     path = tmp_path / "r.json"
     with pytest.raises(ValueError):
         save_risk_settings({"max_dd_per_coin": -0.1}, str(path))
+
+
+def test_restore_defaults(tmp_path):
+    from helpers.utils.strategy_cfg import (
+        restore_defaults,
+        load_strategy_list,
+        save_strategy_list,
+    )
+    default_path = tmp_path / "default.json"
+    strat_path = tmp_path / "strategy.json"
+    backup_path = tmp_path / "backup.json"
+    sample = [{"name": "A", "active": False, "buy_condition": "중도적", "sell_condition": "중도적", "priority": 1}]
+    sample2 = [{"name": "B"}]
+    default_path.write_text(json.dumps(sample, ensure_ascii=False), encoding="utf-8")
+    strat_path.write_text(json.dumps(sample2, ensure_ascii=False), encoding="utf-8")
+    restore_defaults(str(default_path), str(strat_path), str(backup_path))
+    loaded = load_strategy_list(str(strat_path))
+    assert loaded == sample
+    assert backup_path.exists()
 


### PR DESCRIPTION
## Summary
- add helper for strategy config load/save/restore
- load strategy table on startup
- expose `/api/strategies` and default restore API
- implement restore defaults button and JS logic
- add default strategy data
- test restoration utils

## Testing
- `pytest -q` *(fails: command not found)*