### PR TITLE
Add master toggle and revise navigation

### DIFF
--- a/static/js/strategy.js
+++ b/static/js/strategy.js
@@ -3,6 +3,7 @@ const restoreURL = "/api/restore-defaults/strategy";
 const tbody  = document.querySelector("#tbl-strategy tbody");
 const tpl    = document.querySelector("#row-tpl");
 const lastSaved = document.getElementById("last-saved");
+const toggleAll = document.getElementById("toggle-all");
 
 // ────────────────────────────────
 // 1. 초기 로딩
@@ -37,6 +38,7 @@ function renderTable(arr){
   arr.sort((a,b)=>a.priority-b.priority)
      .forEach(obj=>tbody.appendChild(makeRow(obj)));
   lastSaved.textContent = new Date().toLocaleString();
+  applyToggleAll();
 }
 
 function makeRow(o){
@@ -49,18 +51,17 @@ function makeRow(o){
   return tr;
 }
 
-// ────────────────────────────────
-// 3. 전략 추가 (빈 행)
-// ────────────────────────────────
-document.getElementById("btn-add").onclick = ()=>{
-  const obj = {active:true,name:"신규전략",
-               buy_condition:"중도적",sell_condition:"중도적",
-               priority: tbody.children.length+1};
-  tbody.appendChild(makeRow(obj));
-};
+function applyToggleAll(){
+  const on = toggleAll.checked;
+  tbody.querySelectorAll(".active-toggle").forEach(el=>{
+    el.checked = on;
+  });
+}
+
+toggleAll.addEventListener("change", applyToggleAll);
 
 // ────────────────────────────────
-// 4. 저장
+// 3. 저장
 // ────────────────────────────────
 document.getElementById("btn-save").onclick = async ()=>{
   const rows = [...tbody.querySelectorAll("tr")].map(tr=>({

--- a/templates/base.html
+++ b/templates/base.html
@@ -17,12 +17,12 @@
   <div class="collapse navbar-collapse ms-4" id="navbarNav">
     <ul class="navbar-nav">
       <li class="nav-item"><a class="nav-link {% if request.path == '/' %}active{% endif %}" href="/">대시보드</a></li>
-      <li class="nav-item"><a class="nav-link {% if '/dashboard' in request.path %}active{% endif %}" href="/dashboard">모니터</a></li>
-      <li class="nav-item"><a class="nav-link {% if '/strategy' in request.path %}active{% endif %}" href="/strategy">매매설정</a></li>
-      <li class="nav-item"><a class="nav-link {% if '/ai-analysis' in request.path %}active{% endif %}" href="/ai-analysis">AI전략분석</a></li>
+      <li class="nav-item"><a class="nav-link {% if '/dashboard' in request.path %}active{% endif %}" href="/dashboard">실시간 로그</a></li>
+      <li class="nav-item"><a class="nav-link {% if '/strategy' in request.path %}active{% endif %}" href="/strategy">전략 설정</a></li>
+      <li class="nav-item"><a class="nav-link {% if '/ai-analysis' in request.path %}active{% endif %}" href="/ai-analysis">AI 전략분석</a></li>
       <li class="nav-item"><a class="nav-link {% if '/risk' in request.path %}active{% endif %}" href="/risk">리스크관리</a></li>
       <li class="nav-item">
-        <a class="nav-link {% if request.path.startswith('/funds') %}active{% endif %}" href="{{ url_for('funds') }}">자금설정</a>
+        <a class="nav-link {% if request.path.startswith('/funds') %}active{% endif %}" href="{{ url_for('funds') }}">투자설정</a>
       </li>
       <li class="nav-item"><a class="nav-link {% if '/settings' in request.path %}active{% endif %}" href="/settings">개인설정</a></li>
     </ul>

--- a/templates/strategy.html
+++ b/templates/strategy.html
@@ -1,8 +1,17 @@
 {% extends "base.html" %}
+{% set tooltip_text %}
+각 전략은 시장 상황에 맞춰 자동으로 매수와 매도 시점을 판단하여 실행되며, 우선순위가 높을수록 먼저 평가됩니다. 모든 전략은 정지 후에도 설정이 유지되며, 상단 토글을 사용하면 전체 전략을 즉시 켜거나 끌 수 있습니다. 매수와 매도 조건을 세밀하게 조정해 기대 수익률을 높이고 리스크를 최소화해 보세요. 설명이 없는 전략은 향후 업데이트에서 보다 자세한 가이드를 제공할 예정입니다.
+{% endset %}
 {% block content %}
 <div class="container my-4">
   <div class="d-flex justify-content-between align-items-center">
-    <h2 class="fw-bold"><i class="bi bi-kanban-fill me-2"></i>전략 설정</h2>
+    <div class="d-flex align-items-center">
+      <h2 class="fw-bold me-3"><i class="bi bi-kanban-fill me-2"></i>전략 설정</h2>
+      <div class="form-check form-switch">
+        <input class="form-check-input" type="checkbox" id="toggle-all">
+        <label class="form-check-label" for="toggle-all">전체 ON</label>
+      </div>
+    </div>
     <div class="btn-group">
       <button id="btn-restore" class="btn btn-outline-secondary">
         <i class="bi bi-arrow-counterclockwise me-1"></i>기본값 복원
@@ -28,9 +37,6 @@
     <tbody class="text-center"><!-- JS 가 삽입 --></tbody>
   </table>
 
-  <button id="btn-add" class="btn btn-outline-secondary">
-    <i class="bi bi-plus-lg"></i> 전략 추가
-  </button>
 </div>
 
 <!-- 템플릿 row (JS 가 clone) -->
@@ -57,7 +63,7 @@
     </td>
     <td>
       <button class="btn btn-sm btn-outline-info info-btn"
-              data-bs-toggle="tooltip" title="전략 설명 미등록">
+              data-bs-toggle="tooltip" title="{{ tooltip_text|trim }}">
         <i class="bi bi-info-circle"></i>
       </button>
     </td>


### PR DESCRIPTION
## Summary
- update navigation labels according to new spec
- add global ON/OFF toggle to strategy page and remove add-button
- expand tooltip text for strategy descriptions
- sync toggle behaviour in strategy JavaScript

## Testing
- `pytest -q` *(fails: command not found)*