### PR TITLE
Fix funds settings saving

### DIFF
--- a/app.py
+++ b/app.py
@@ -1028,7 +1028,11 @@ def api_get_funds():
 def api_post_funds():
     from helpers.utils.funds import save_fund_settings, load_fund_settings
     data = request.get_json(force=True)
-    save_fund_settings(data)
+    try:
+        save_fund_settings(data)
+    except Exception as e:
+        logger.error("Funds save failed: %s", e)
+        return jsonify(result="error", message=str(e)), 400
     return jsonify(load_fund_settings())
 
 @app.route("/settings")

--- a/helpers/utils/funds.py
+++ b/helpers/utils/funds.py
@@ -1,5 +1,9 @@
 import os
 import json
+import threading
+
+# 파일 동시 접근 방지를 위한 락
+_LOCK = threading.Lock()
 
 
 def _validate(data: dict) -> None:
@@ -35,5 +39,7 @@ def save_fund_settings(data: dict, path: str = "config/funds.json") -> None:
     """자금 설정을 저장하고 업데이트 시각을 기록한다."""
     _validate(data)
     data["updated"] = __import__("datetime").datetime.now().isoformat(timespec="seconds")
-    with open(path, "w", encoding="utf-8") as f:
-        json.dump(data, f, ensure_ascii=False, indent=2)
+    # 락을 이용해 동시 접근을 제어한다
+    with _LOCK:
+        with open(path, "w", encoding="utf-8") as f:
+            json.dump(data, f, ensure_ascii=False, indent=2)

--- a/static/js/funds.js
+++ b/static/js/funds.js
@@ -40,8 +40,8 @@ document.getElementById("btn-fund-save").onclick = async () => {
     body: JSON.stringify(payload)
   });
   if (res.ok) {
-    const data = await res.json();
     showAlert("자금 설정이 저장되었습니다.");
+    const data = await fetch(apiURL).then(r => r.json());
     f("max-per-coin").value = data.max_invest_per_coin;
     f("buy-amount").value = data.buy_amount;
     f("max-trades").value = data.max_concurrent_trades;
@@ -51,6 +51,7 @@ document.getElementById("btn-fund-save").onclick = async () => {
       data.updated ? new Date(data.updated).toLocaleString() : "-";
     document.dispatchEvent(new CustomEvent("fundsUpdated", { detail: data }));
   } else {
-    showAlert("저장 실패", "에러");
+    const err = await res.json().catch(() => ({}));
+    showAlert(err.message || "저장 실패", "에러");
   }
 };


### PR DESCRIPTION
## Summary
- lock funds.json writes for concurrency
- return error details from POST `/api/funds`
- refresh form via GET after saving

## Testing
- `pytest -q` *(fails: pytest not installed)*