### PR TITLE
Disable email notifications via comments

### DIFF
--- a/README.md
+++ b/README.md
@@ -138,6 +138,11 @@ All API keys and tokens are read from `config/secrets.json`. Create the file bef
   "UPBIT_SECRET": "YOUR-UPBIT-SECRET",
   "TELEGRAM_TOKEN": "BOT-TOKEN",
   "TELEGRAM_CHAT_ID": "123456789"
+  // "EMAIL_HOST": "smtp.example.com",
+  // "EMAIL_PORT": 587,
+  // "EMAIL_USER": "bot@example.com",
+  // "EMAIL_PASSWORD": "pass",
+  // "EMAIL_TO": "notify@example.com"  // 이메일 알림은 비활성화 상태
 }
 ```
 

--- a/app.py
+++ b/app.py
@@ -17,6 +17,7 @@ from utils import (
     load_filter_settings,
 )
 from trader import Trader
+import notifications
 from notifications import notify, notify_error
 from bot.runtime_settings import settings, load_from_file
 from helpers.logger import log_trade, get_recent_logs
@@ -75,6 +76,13 @@ notifications.init(
     socketio,
     secrets.get("TELEGRAM_TOKEN"),
     secrets.get("TELEGRAM_CHAT_ID"),
+    # {
+    #     "host": secrets.get("EMAIL_HOST"),
+    #     "port": secrets.get("EMAIL_PORT"),
+    #     "user": secrets.get("EMAIL_USER"),
+    #     "password": secrets.get("EMAIL_PASSWORD"),
+    #     "to": secrets.get("EMAIL_TO"),
+    # },  # 이메일 알림 비활성화
 )
 
 # 기본 계좌 요약 자리표시자

--- a/config/secrets.json
+++ b/config/secrets.json
@@ -4,6 +4,12 @@
   "TELEGRAM_TOKEN": "7247114986:AAHwL_xDWAwzFrsuyIqsOCHokRY45qwKF0A",
   "TELEGRAM_CHAT_ID": "5901563365",
 
+  "#EMAIL_HOST": "smtp.example.com",
+  "#EMAIL_PORT": 587,
+  "#EMAIL_USER": "bot@example.com",
+  "#EMAIL_PASSWORD": "change-me",
+  "#EMAIL_TO": "notify@example.com",
+
   "__설명1": "UPBIT_KEY/UPBIT_SECRET: 업비트 API 키/시크릿. 반드시 본인 것으로 교체!",
   "__설명2": "TELEGRAM_TOKEN: @BotFather로 만든 텔레그램 봇의 API 토큰(알림 기능용)",
   "__설명3": "TELEGRAM_CHAT_ID: @userinfobot 등으로 얻는 개인/그룹 채팅 ID"

--- a/notifications.py
+++ b/notifications.py
@@ -13,22 +13,43 @@ logger = logging.getLogger(__name__)
 _socketio: Optional[SocketIO] = None
 _token: Optional[str] = None
 _chat_id: Optional[str] = None
+# _email: dict | None = None  # 이메일 알림 미사용
 
 
-def init(socketio: Optional[SocketIO], token: Optional[str], chat_id: Optional[str]) -> None:
-    global _socketio, _token, _chat_id
+def init(
+    socketio: Optional[SocketIO],
+    token: Optional[str],
+    chat_id: Optional[str],
+    # email: dict | None = None,
+) -> None:
+    global _socketio, _token, _chat_id  # , _email
     _socketio = socketio
     _token = token
     _chat_id = chat_id
+    # _email = None
+    # if email and all(email.get(k) for k in ["host", "port", "user", "password", "to"]):
+    #     _email = email
+    # elif email:
+    #     logger.warning("Incomplete email configuration; email notifications disabled")
 
 
 def notify(message: str) -> None:
-    """Send message to browser via SocketIO and Telegram if enabled."""
+    """SocketIO와 텔레그램으로 알림을 전송한다."""
     logger.debug("[NOTIFY] %s", message)
     if _socketio:
         _socketio.emit("notification", {"message": message})
     if _token and _chat_id:
         send_telegram(_token, _chat_id, message)
+    # if _email:
+    #     send_email(
+    #         _email["host"],
+    #         int(_email["port"]),
+    #         _email["user"],
+    #         _email["password"],
+    #         _email["to"],
+    #         "Notification",
+    #         message,
+    #     )
 
 
 def notify_error(message: str, code: str) -> None:

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -20,6 +20,24 @@ if 'pyupbit' not in sys.modules:
     pyupbit.get_orderbook = lambda *a, **k: None
     sys.modules['pyupbit'] = pyupbit
 
+# if 'smtplib' not in sys.modules:
+#     smtplib = types.ModuleType('smtplib')
+#     class DummySMTP:
+#         def __init__(self, *a, **k):
+#             pass
+#         def __enter__(self):
+#             return self
+#         def __exit__(self, *a):
+#             pass
+#         def starttls(self):
+#             pass
+#         def login(self, *a):
+#             pass
+#         def sendmail(self, *a, **k):
+#             pass
+#     smtplib.SMTP = DummySMTP
+#     sys.modules['smtplib'] = smtplib
+
 import utils
 from helpers.utils.funds import load_fund_settings, save_fund_settings
 from helpers.utils.risk import save_risk_settings
@@ -90,4 +108,15 @@ def test_restore_defaults(tmp_path):
     loaded = load_strategy_list(str(strat_path))
     assert loaded == sample
     assert backup_path.exists()
+
+
+# def test_send_email():
+#     """SMTP 서버 호출 여부를 확인한다."""
+#     with patch('utils.smtplib.SMTP') as mock_smtp:
+#         instance = mock_smtp.return_value.__enter__.return_value
+#         utils.send_email('h', 1, 'u', 'p', 't', 's', 'b')
+#         mock_smtp.assert_called_with('h', 1, timeout=5)
+#         instance.starttls.assert_called_once()
+#         instance.login.assert_called_once_with('u', 'p')
+#         instance.sendmail.assert_called_once()
 

--- a/utils.py
+++ b/utils.py
@@ -4,6 +4,8 @@ import os
 import sys
 from typing import Iterable
 import time
+# import smtplib
+# from email.mime.text import MIMEText
 
 import pandas as pd
 import requests
@@ -87,6 +89,30 @@ def send_telegram(token: str, chat_id: str, text: str) -> None:
         logging.info("Telegram message sent")
     except Exception as e:
         logging.exception("Telegram send failed: %s", e)
+
+
+# def send_email(
+#     host: str,
+#     port: int,
+#     user: str,
+#     password: str,
+#     to_addr: str,
+#     subject: str,
+#     body: str,
+# ) -> None:
+#     """SMTP 서버로 이메일을 전송한다."""
+#     msg = MIMEText(body)
+#     msg["Subject"] = subject
+#     msg["From"] = user
+#     msg["To"] = to_addr
+#     try:
+#         with smtplib.SMTP(host, port, timeout=5) as server:
+#             server.starttls()
+#             server.login(user, password)
+#             server.sendmail(user, [to_addr], msg.as_string())
+#         logging.info("Email sent")
+#     except Exception as e:  # SMTP 오류 무시
+#         logging.exception("Email send failed: %s", e)
 
 
 def load_secrets(


### PR DESCRIPTION
## Summary
- comment out email config example in README and secrets
- disable email setup in app initialization
- fully comment email functions in notifications and utils
- skip SMTP mocks and email tests

## Testing
- `pytest -q` *(fails: command not found)*