### PR TITLE
Add strategy loader and validation

### DIFF
--- a/strategy_loader.py
+++ b/strategy_loader.py
@@ -1,0 +1,44 @@
+"""Strategy specification loader."""
+
+from __future__ import annotations
+
+import json
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Dict, List
+
+
+@dataclass
+class StrategySpec:
+    """단일 전략 정의."""
+
+    id: int
+    name: str
+    short_code: str
+    buy_formula: str
+    sell_formula: str
+    buy_levels: List[List[str]]
+    sell_levels: List[List[str]]
+    params: dict
+
+
+def load_strategies(path: str | Path = "config/strategies_master.json") -> Dict[str, StrategySpec]:
+    """Return mapping of short_code to StrategySpec."""
+    with open(path, "r", encoding="utf-8") as f:
+        data = json.load(f)
+    result = {}
+    for item in data:
+        spec = StrategySpec(
+            id=item.get("id"),
+            name=item.get("name"),
+            short_code=item.get("short_code"),
+            buy_formula=item.get("buy_formula", ""),
+            sell_formula=item.get("sell_formula", ""),
+            buy_levels=item.get("buy_levels", []),
+            sell_levels=item.get("sell_levels", []),
+            params=item.get("params", {}),
+        )
+        result[spec.short_code] = spec
+    return result
+
+

--- a/validate_strategies.py
+++ b/validate_strategies.py
@@ -1,0 +1,27 @@
+"""Verify strategy definitions against code."""
+
+from __future__ import annotations
+
+import inspect
+import importlib
+
+from strategy_loader import load_strategies
+
+
+def main() -> None:
+    specs = load_strategies()
+    codes = importlib.import_module("bot.strategy")
+    available = {name for name, _ in inspect.getmembers(codes, inspect.isfunction)}
+    missing = []
+    for sc, spec in specs.items():
+        if spec.short_code not in available:
+            missing.append(spec.short_code)
+    if missing:
+        print("[WARN] missing strategy implementations:", ", ".join(missing))
+    else:
+        print("All strategies implemented")
+
+
+if __name__ == "__main__":
+    main()
+


### PR DESCRIPTION
## Summary
- add `strategy_loader.py` for loading strategy specs from JSON
- check strategy existence in helper functions and load specs on import
- add `validate_strategies.py` script to detect missing implementations

## Testing
- `pytest -q` *(fails: `pytest` not found)*