### PR TITLE
Implement strategy priority utilities

### DIFF
--- a/helpers/__init__.py
+++ b/helpers/__init__.py
@@ -1,0 +1,2 @@
+__all__ = ['bot', 'execution', 'logger', 'strategies', 'priorities', 'utils']
+

--- a/helpers/priorities.py
+++ b/helpers/priorities.py
@@ -1,0 +1,44 @@
+"""Strategy priority and conflict resolution utilities."""
+
+from __future__ import annotations
+
+from typing import Any, Dict, List, Optional
+
+from helpers.strategies import check_buy_signal
+
+
+def active_strategies(strategies: List[Dict[str, Any]]) -> List[Dict[str, Any]]:
+    """Return active strategies sorted by priority."""
+    return sorted(
+        [s for s in strategies if s.get("active")],
+        key=lambda s: s.get("priority", 9999),
+    )
+
+
+def select_buy_strategy(
+    market: Dict[str, Any], strategies: List[Dict[str, Any]]
+) -> Optional[str]:
+    """Return the highest priority strategy with a buy signal."""
+    for s in active_strategies(strategies):
+        name = s.get("name")
+        level = s.get("buy_condition", "중도적")
+        if check_buy_signal(name, level, market):
+            return name
+    return None
+
+
+_SIGNAL_ORDER = ["ban", "avoid", "sell", "buy", "wait"]
+
+
+def resolve_signal(flags: Dict[str, bool]) -> str:
+    """Return highest priority signal from flag mapping."""
+    for key in _SIGNAL_ORDER:
+        if flags.get(key):
+            return key
+    return "wait"
+
+__all__ = [
+    "active_strategies",
+    "select_buy_strategy",
+    "resolve_signal",
+]

--- a/tests/test_priorities.py
+++ b/tests/test_priorities.py
@@ -1,0 +1,36 @@
+import types
+from helpers import priorities
+
+
+def test_active_strategies_sorting():
+    data = [
+        {"name": "B", "active": True, "priority": 2},
+        {"name": "A", "active": True, "priority": 1},
+        {"name": "C", "active": False, "priority": 0},
+    ]
+    res = priorities.active_strategies(data)
+    assert [s["name"] for s in res] == ["A", "B"]
+
+
+def test_select_buy_strategy(monkeypatch):
+    calls = []
+
+    def fake_check(name, level, market):
+        calls.append(name)
+        return name == "B"
+
+    monkeypatch.setattr(priorities, "check_buy_signal", fake_check)
+    data = [
+        {"name": "A", "active": True, "buy_condition": "중도적", "priority": 2},
+        {"name": "B", "active": True, "buy_condition": "중도적", "priority": 1},
+    ]
+    sel = priorities.select_buy_strategy({}, data)
+    assert sel == "B"
+    assert calls == ["B"]
+
+
+def test_resolve_signal():
+    flags = {"buy": True, "avoid": True}
+    assert priorities.resolve_signal(flags) == "avoid"
+    flags = {"wait": True}
+    assert priorities.resolve_signal(flags) == "wait"


### PR DESCRIPTION
## Summary
- add priority handling helpers
- export new helpers
- support strategy table reload and selection in trading bot
- test priority utilities

## Testing
- `python -m pytest -q` *(fails: No module named pytest)*