### PR TITLE
Add MFI14 and VWAP indicators

### DIFF
--- a/bot/indicators.py
+++ b/bot/indicators.py
@@ -55,6 +55,18 @@ def compute_indicators(df):
     # We can similarly compute shorter volume averages if needed (like 5).
     df['Vol_MA5'] = df['Volume'].rolling(window=5).mean()
 
+    # 5. MFI(Money Flow Index)와 VWAP 계산
+    tp = (df['High'] + df['Low'] + df['Close']) / 3
+    raw_mf = tp * df['Volume']
+    pos_mf = raw_mf.where(tp > tp.shift(1), 0.0)
+    neg_mf = raw_mf.where(tp < tp.shift(1), 0.0)
+    mf_ratio = pos_mf.rolling(window=14).sum() / (neg_mf.rolling(window=14).sum() + 1e-9)
+    df['MFI14'] = 100 - (100 / (1 + mf_ratio))
+
+    vwap_num = (tp * df['Volume']).cumsum()
+    vwap_den = df['Volume'].cumsum()
+    df['VWAP'] = vwap_num / vwap_den
+
     # 5. Bollinger Bands (20-period, 2 std)
     period = 20
     std = 2

--- a/helpers/strategies.py
+++ b/helpers/strategies.py
@@ -33,7 +33,7 @@ def evaluate_buy_signals(strategy, risk_level):
     if '_prev' in formula_eval:
         # create columns with suffix for previous values
         for col in ['Close','Open','High','Low','Volume','Strength','EMA5','EMA20','EMA60','EMA120',
-                    'ATR14','RSI14','MFI14','CCI20','MACD_hist','BandWidth20']:
+                    'ATR14','RSI14','MFI14','VWAP','CCI20','MACD_hist','BandWidth20']:
             if col in df and f'{col}_prev' in formula_eval:
                 df[f'{col}_prev'] = df[col].shift(1)
             if col in df and f'{col}_prev2' in formula_eval:


### PR DESCRIPTION
## Summary
- compute Money Flow Index and VWAP in indicator helper
- support VWAP offsets in strategy evaluation

## Testing
- `pip install pytest` *(fails: Could not find a version that satisfies the requirement)*