### PR TITLE
Precompute Bollinger width minima

### DIFF
--- a/bot/indicators.py
+++ b/bot/indicators.py
@@ -76,6 +76,9 @@ def compute_indicators(df):
     df['BB_lower'] = df['BB_mid'] - std * df['BB_std']
     # Bollinger Band Width (difference between bands)
     df['BandWidth20'] = df['BB_upper'] - df['BB_lower']
+    # Precompute rolling minima for BandWidth20 for strategy formulas
+    df['BandWidth20_min10'] = df['BandWidth20'].rolling(window=10).min()
+    df['BandWidth20_min20'] = df['BandWidth20'].rolling(window=20).min()
 
     # 6. Rolling max/min for various look-back periods
     df['MaxHigh5'] = df['High'].rolling(window=5).max()

--- a/config/strategies_master.json
+++ b/config/strategies_master.json
@@ -534,8 +534,8 @@
         ],
         "buy_formula_levels": [
             "BandWidth20 < BandWidth20(-1) and BandWidth20(-1) < BandWidth20(-2) and Close > BB_upper(20,2) and Vol(0) >= MA(Vol,20) * 2",
-            "BandWidth20 == BandWidth20.rolling(10).min() and Close > BB_upper(20,2) and Vol(0) >= MA(Vol,20) * 3",
-            "BandWidth20 == BandWidth20.rolling(20).min() and Close > BB_upper(20,2) and Vol(0) >= MA(Vol,20) * 4"
+            "BandWidth20 == BandWidth20_min10 and Close > BB_upper(20,2) and Vol(0) >= MA(Vol,20) * 3",
+            "BandWidth20 == BandWidth20_min20 and Close > BB_upper(20,2) and Vol(0) >= MA(Vol,20) * 4"
         ],
         "sell_levels": [
             [
@@ -716,7 +716,7 @@
         "buy_formula_levels": [
             "BandWidth20 < BandWidth20(-1) and BandWidth20(-1) < BandWidth20(-2) and Close > BB_upper(20,2) and Vol(0) >= MA(Vol,20) * 2",
             "BandWidth20 < BandWidth20(-1) and Close > BB_upper(20,2) and Vol(0) >= MA(Vol,20) * 2.5",
-            "BandWidth20 == BandWidth20.rolling(20).min() and Close > BB_upper(20,2) and Vol(0) >= MA(Vol,20) * 3"
+            "BandWidth20 == BandWidth20_min20 and Close > BB_upper(20,2) and Vol(0) >= MA(Vol,20) * 3"
         ],
         "sell_levels": [
             [


### PR DESCRIPTION
## Summary
- add `BandWidth20_min10` and `BandWidth20_min20` in `compute_indicators`
- reference these rolling minima inside `strategies_master.json`

## Testing
- `pytest -q` *(fails: command not found)*