### PR TITLE
Fix _normalize offset handling

### DIFF
--- a/helpers/strategies.py
+++ b/helpers/strategies.py
@@ -25,6 +25,19 @@ def _normalize(formula: str) -> str:
 
     # e.g. MFI(14,-1) -> MFI14_prev, Tenkan(9,-26) -> Tenkan9_next26
     formula = re.sub(r"([A-Za-z_]+)\((\d+),\s*(-?\d+)\)", _repl_multi, formula)
+
+    # Close(-1) -> Close_prev, Low(0) -> Low
+    def _repl_offset(match: re.Match) -> str:
+        col, off = match.group(1), int(match.group(2))
+        result = col
+        if off < 0:
+            result += "_prev" + (str(-off) if off != -1 else "")
+        elif off > 0:
+            result += "_next" + (str(off) if off != 1 else "")
+        return result
+
+    formula = re.sub(r"(\b[A-Za-z_][A-Za-z0-9_]*)\((-?\d+)\)", _repl_offset, formula)
+
     # e.g. EMA(5) -> EMA5
     formula = re.sub(r"([A-Za-z_]+)\((\d+)\)", lambda m: f"{m.group(1)}{m.group(2)}", formula)
 
@@ -42,18 +55,6 @@ def _normalize(formula: str) -> str:
         return result
 
     formula = re.sub(r"(BB_(?:upper|lower))\(\d+,\s*\d+(?:,\s*(-?\d+))?\)", _repl_bb, formula)
-
-    # Close(-1) -> Close_prev
-    def _repl_offset(match: re.Match) -> str:
-        col, off = match.group(1), int(match.group(2))
-        result = col
-        if off < 0:
-            result += "_prev" + (str(-off) if off != -1 else "")
-        elif off > 0:
-            result += "_next" + (str(off) if off != 1 else "")
-        return result
-
-    formula = re.sub(r"(\b[A-Za-z_][A-Za-z0-9_]*)\((-?\d+)\)", _repl_offset, formula)
     return formula
 
 

--- a/tests/test_strategies.py
+++ b/tests/test_strategies.py
@@ -1,5 +1,10 @@
 import pandas as pd
-from helpers.strategies import check_buy_signal, check_sell_signal, df_to_market
+from helpers.strategies import (
+    check_buy_signal,
+    check_sell_signal,
+    df_to_market,
+    _normalize,
+)
 
 
 def _base_df(rows=80):
@@ -108,3 +113,8 @@ def test_sell_signals():
         df = make_df(strat)
         market = df_to_market(df, 1.0)
         assert check_sell_signal(strat, "공격적", market)
+
+
+def test_normalize_zero_offset():
+    assert _normalize("Low(0)") == "Low"
+    assert _normalize("Vol(0)") == "Vol"


### PR DESCRIPTION
## Summary
- ensure offset zero calls like `Low(0)` become `Low`
- run zero-offset substitutions before single-argument pattern
- test `_normalize` with zero offsets

## Testing
- `pytest -q` *(fails: command not found)*