### PR TITLE
Fix volume token normalization

### DIFF
--- a/tests/test_strategies.py
+++ b/tests/test_strategies.py
@@ -117,4 +117,6 @@ def test_sell_signals():
 
 def test_normalize_zero_offset():
     assert _normalize("Low(0)") == "Low"
-    assert _normalize("Vol(0)") == "Vol"
+    assert _normalize("Vol(0)") == "Volume"
+    assert _normalize("Vol(-1)") == "Volume_prev"
+    assert _normalize("MA(Vol,20)") == "Volume_MA20"


### PR DESCRIPTION
## Summary
- normalize formula tokens `Vol`, `Vol_prev`, `Vol_MA20` to reference the `Volume` column
- update tests for new normalization rules

## Testing
- `pytest -q` *(fails: command not found)*