### PR TITLE
Fix volume MA normalization

### DIFF
--- a/helpers/strategies.py
+++ b/helpers/strategies.py
@@ -60,8 +60,9 @@ def _normalize(formula: str) -> str:
     # 4) Offsets such as Close(-1) or PSAR(1)
     formula = re.sub(r"(\b[A-Za-z_][A-Za-z0-9_]*)\((-?\d+)\)", _repl_offset, formula)
 
-    # 5) Rename Vol column to Volume
-    formula = re.sub(r"\bVol(?=\b|_)", "Volume", formula)
+    # 5) Rename Vol column to Volume, except for volume moving averages
+    #    such as Vol_MA20 which should keep the Vol prefix.
+    formula = re.sub(r"\bVol(?!_MA\d+)(?=\b|_)", "Volume", formula)
 
     return formula
 

--- a/tests/test_strategies.py
+++ b/tests/test_strategies.py
@@ -142,3 +142,7 @@ def test_normalize_zero_offset():
 def test_normalize_offsets():
     assert _normalize("Close(-1)") == "Close_prev"
     assert _normalize("PSAR(1)") == "PSAR_prev"
+
+
+def test_normalize_volume_ma():
+    assert _normalize("MA(Vol,20)") == "Vol_MA20"


### PR DESCRIPTION
## Summary
- keep `Vol` prefix for volume MA columns in `_normalize`
- test for `MA(Vol,20)` normalization

## Testing
- `python -m pytest -q` *(fails: No module named pytest)*