### PR TITLE
Clarify origin of Strength indicator

### DIFF
--- a/bot/indicators.py
+++ b/bot/indicators.py
@@ -11,15 +11,22 @@ def calc_indicators(df: pd.DataFrame) -> pd.DataFrame:
     """
     return compute_indicators(df)
 
-def compute_indicators(df):
+def compute_indicators(df, strength=None):
     """
-    Compute all indicators and derived fields required by strategy formulas.
-    Assumes df has at least 'Open', 'High', 'Low', 'Close', 'Volume', and optionally 'Strength'.
-    Returns the DataFrame with new indicator columns added.
+    전략 포뮬러 계산에 필요한 각종 지표를 생성한다.
+
+    ``Strength`` 컬럼은 체결강도(TIS) 값으로, 보통 :func:`utils.calc_tis`
+    결과를 사용한다. ``strength`` 인수를 지정하면 해당 값을 ``Strength``
+    열에 채워 넣고, 컬럼이 없을 경우 0으로 초기화한다.
     """
     # Ensure DataFrame is sorted in time order
     df = df.copy()
     df = df.reset_index(drop=True)
+
+    if strength is not None:
+        df['Strength'] = strength
+    elif 'Strength' not in df.columns:
+        df['Strength'] = 0
 
     # 1. Exponential Moving Averages (EMA)
     df['EMA5'] = df['Close'].ewm(span=5, adjust=False).mean()

--- a/docs/BUY_MONITOR_SPEC_KR.md
+++ b/docs/BUY_MONITOR_SPEC_KR.md
@@ -83,6 +83,10 @@
 - **케이스 4:** 🔻 95 미만
 - **UI 예시**: `<span class="tis-high">⏫ 135</span>`
 
+해당 체결강도 값은 전략 수식에서 **Strength** 컬럼으로 사용됩니다. `utils.calc_tis()`
+함수를 통해 계산한 값을 `compute_indicators()` 호출 전에 DataFrame에
+`Strength` 열로 추가하면 전략 조건식을 그대로 평가할 수 있습니다.
+
 ### 2.7 GC (골든/데드크로스)
 - **툴팁**
   - EMA5가 EMA20을 상향 돌파하면 골든크로스(GC)로 판단합니다.

--- a/tests/test_strategies.py
+++ b/tests/test_strategies.py
@@ -142,3 +142,12 @@ def test_normalize_zero_offset():
 def test_normalize_offsets():
     assert _normalize("Close(-1)") == "Close_prev"
     assert _normalize("PSAR(1)") == "PSAR_prev"
+
+
+def test_compute_indicators_strength():
+    idx = pd.date_range("2021-01-01", periods=5, freq="5T")
+    base = {"Open": [1]*5, "High": [1]*5, "Low": [1]*5, "Close": [1]*5, "Volume": [1]*5}
+    df = pd.DataFrame(base, index=idx)
+    res = compute_indicators(df, strength=123)
+    assert "Strength" in res.columns
+    assert res["Strength"].iloc[0] == 123


### PR DESCRIPTION
## Summary
- document that Strength column uses TIS from `calc_tis`
- allow `compute_indicators` to fill a Strength column when given
- test new helper behaviour

## Testing
- `pytest -q` *(fails: Could not install pytest)*