### PR TITLE
Fix MA normalization duplication

### DIFF
--- a/helpers/strategies.py
+++ b/helpers/strategies.py
@@ -15,8 +15,6 @@ def _normalize(formula: str) -> str:
 
     formula = re.sub(r"MA\(ATR\((\d+)\),\s*(\d+)\)", _repl_ma_atr, formula)
 
-    # Replace MA(Vol,20) -> Vol_MA20
-    formula = re.sub(r"MA\((\w+),\s*(\d+)\)", r"\1_MA\2", formula)
 
     def _repl_multi(match: re.Match) -> str:
         name, period, offset = match.group(1), match.group(2), match.group(3)

--- a/tests/test_strategies.py
+++ b/tests/test_strategies.py
@@ -143,6 +143,11 @@ def test_normalize_offsets():
     assert _normalize("Close(-1)") == "Close_prev"
     assert _normalize("PSAR(1)") == "PSAR_prev"
 
+
+def test_normalize_ma_vol_and_atr():
+    assert _normalize("MA(Vol,20)") == "Vol_MA20"
+    assert _normalize("MA(ATR(14),20)") == "ATR14_MA20"
+
     
 def test_compute_indicators_strength():
     idx = pd.date_range("2021-01-01", periods=5, freq="5T")


### PR DESCRIPTION
## Summary
- remove duplicate MA replacement in `_normalize`
- test `MA(Vol,20)` and `MA(ATR(14),20)` normalization

## Testing
- `pytest -q` *(fails: command not found)*