### PR TITLE
Use formula-based signals for buy and sell

### DIFF
--- a/helpers/strategies.py
+++ b/helpers/strategies.py
@@ -138,7 +138,11 @@ def check_buy_signal(strategy_name: str, level: str, market: Dict[str, Any]) -> 
     spec = _SPEC_CACHE.get(strategy_name)
     if not spec:
         return False
-    res = evaluate_buy_signals(market["df"], spec.__dict__, level)
+    res = evaluate_buy_signals(
+        market["df"],
+        {"buy_formula_levels": spec.buy_formula_levels},
+        level,
+    )
     return bool(res.iloc[-1])
 
 
@@ -149,5 +153,11 @@ def check_sell_signal(strategy_name: str, level: str, market: Dict[str, Any]) ->
         return False
     entry = market.get("Entry", 0.0)
     peak = market.get("Peak", market["df"]["High"].cummax().iloc[-1])
-    res = evaluate_sell_signals(market["df"], spec.__dict__, level, entry, peak)
+    res = evaluate_sell_signals(
+        market["df"],
+        {"sell_formula_levels": spec.sell_formula_levels},
+        level,
+        entry,
+        peak,
+    )
     return bool(res.iloc[-1])

--- a/strategy_loader.py
+++ b/strategy_loader.py
@@ -19,6 +19,8 @@ class StrategySpec:
     sell_formula: str
     buy_levels: List[List[str]]
     sell_levels: List[List[str]]
+    buy_formula_levels: List[str]
+    sell_formula_levels: List[str]
     params: dict
 
 
@@ -36,6 +38,8 @@ def load_strategies(path: str | Path = "config/strategies_master.json") -> Dict[
             sell_formula=item.get("sell_formula", ""),
             buy_levels=item.get("buy_levels", []),
             sell_levels=item.get("sell_levels", []),
+            buy_formula_levels=item.get("buy_formula_levels", []),
+            sell_formula_levels=item.get("sell_formula_levels", []),
             params=item.get("params", {}),
         )
         result[spec.short_code] = spec


### PR DESCRIPTION
## Summary
- include buy_formula_levels and sell_formula_levels in strategy specs
- fetch these formulas when checking buy and sell signals
- drop the placeholder sell check

## Testing
- `pytest -q` *(fails: command not found)*