### PR TITLE
Implement sell-signal evaluation

### DIFF
--- a/helpers/strategies.py
+++ b/helpers/strategies.py
@@ -100,7 +100,11 @@ def _apply_shifts(df: pd.DataFrame, formula: str) -> pd.DataFrame:
 
 def evaluate_buy_signals(df: pd.DataFrame, strategy: Dict[str, Any], risk_level: Any) -> pd.Series:
     level_idx = RISK_LEVELS.get(risk_level, risk_level)
-    formula = strategy['buy_formula_levels'][level_idx]
+    levels = strategy.get('buy_formula_levels')
+    if levels:
+        formula = levels[level_idx]
+    else:
+        formula = strategy.get('buy_formula', '')
     expr = formula.replace(' and ', ' & ').replace(' or ', ' | ')
     expr = _normalize(expr)
     df = _apply_shifts(df, expr)
@@ -123,7 +127,11 @@ def evaluate_sell_signals(
 ) -> pd.Series:
     """매도 전략 포뮬러를 평가한다."""
     level_idx = RISK_LEVELS.get(risk_level, risk_level)
-    formula = strategy["sell_formula_levels"][level_idx]
+    levels = strategy.get("sell_formula_levels")
+    if levels:
+        formula = levels[level_idx]
+    else:
+        formula = strategy.get("sell_formula", "")
     expr = formula.replace(" and ", " & ").replace(" or ", " | ")
     expr = _normalize(expr)
     df = _apply_shifts(df, expr)

--- a/strategy_loader.py
+++ b/strategy_loader.py
@@ -19,6 +19,8 @@ class StrategySpec:
     sell_formula: str
     buy_levels: List[List[str]]
     sell_levels: List[List[str]]
+    buy_formula_levels: List[str]
+    sell_formula_levels: List[str]
     params: dict
 
 
@@ -36,6 +38,8 @@ def load_strategies(path: str | Path = "config/strategies_master.json") -> Dict[
             sell_formula=item.get("sell_formula", ""),
             buy_levels=item.get("buy_levels", []),
             sell_levels=item.get("sell_levels", []),
+            buy_formula_levels=item.get("buy_formula_levels", []),
+            sell_formula_levels=item.get("sell_formula_levels", []),
             params=item.get("params", {}),
         )
         result[spec.short_code] = spec

--- a/tests/test_strategies.py
+++ b/tests/test_strategies.py
@@ -132,6 +132,8 @@ def test_sell_signals():
     ]:
         df = make_df(strat)
         market = df_to_market(df, 1.0)
+        market["Entry"] = df["Close"].iloc[-1] * 0.97
+        market["Peak"] = df["High"].cummax().iloc[-1]
         assert check_sell_signal(strat, "공격적", market)
 
 


### PR DESCRIPTION
## Summary
- load risk level formulas in `strategy_loader`
- evaluate buy/sell signals with risk-level formulas
- provide entry/peak info in sell-signal tests

## Testing
- `pytest -q` *(fails: command not found)*