### PR TITLE
Update start_bot notification

### DIFF
--- a/app.py
+++ b/app.py
@@ -1052,9 +1052,11 @@ def start_bot():
             logger.info("Start request ignored: already running")
             return jsonify(result="error", message="봇이 이미 실행중입니다.", status=get_status())
         settings.running = True
+        buy_amount = trader.config.get("amount", settings.buy_amount)
+        max_pos = trader.config.get("max_positions", settings.max_positions)
         msg = (
             f"봇 시작: 전략 {settings.strategy}, "
-            f"1회 매수 {settings.buy_amount:,}원, 최대 {settings.max_positions}종목"
+            f"1회 매수 {buy_amount:,}원, 최대 {max_pos}종목"
         )
         notify(msg)
         log_trade("bot", {"action": "start"})

--- a/tests/test_app.py
+++ b/tests/test_app.py
@@ -1,0 +1,22 @@
+import pytest
+
+from app import app, start_bot, trader, settings
+
+
+def test_start_bot_uses_trader_config(monkeypatch):
+    messages = []
+    monkeypatch.setattr('app.notify', lambda m: messages.append(m))
+    monkeypatch.setattr('app.get_filtered_tickers', lambda: ['KRW-TEST'])
+    monkeypatch.setattr(trader, 'set_tickers', lambda tickers: None)
+    monkeypatch.setattr(trader, 'start', lambda: True)
+
+    monkeypatch.setitem(trader.config, 'amount', 11111)
+    monkeypatch.setitem(trader.config, 'max_positions', 3)
+    settings.running = False
+    settings.buy_amount = 22222
+    settings.max_positions = 9
+
+    with app.test_request_context('/api/start-bot', method='POST'):
+        resp = start_bot()
+    assert resp.json['result'] == 'success'
+    assert messages and '11,111' in messages[0] and '3종목' in messages[0]


### PR DESCRIPTION
## Summary
- use trader.config values in the start_bot notification
- ensure message uses current trader config

## Testing
- `pytest -q` *(fails: command not found)*