### PR TITLE
Fix strategy display for positions

### DIFF
--- a/bot/trader.py
+++ b/bot/trader.py
@@ -310,8 +310,8 @@ class UpbitTrader:
         params = self.config.get("params", {})
         sl_pct = params.get("sl", 0) * 100
         tp_pct = params.get("tp", 0) * 100
-        strategy_code = self.config.get("strategy", "-")
-        risk_level = self.config.get("level", "중도적")
+        default_strategy = self.config.get("strategy", "-")
+        default_level = self.config.get("level", "중도적")
         for b in balances:
             currency = b.get("currency")
             bal = float(b.get("balance", 0))
@@ -328,6 +328,13 @@ class UpbitTrader:
                     self.logger.warning("Price lookup failed for %s", currency)
                 self._alert(f"[API Exception] 시세 조회 실패: {currency}")
                 price = 0
+            ticker = f"KRW-{currency}"
+            strategy_code = default_strategy
+            risk_level = default_level
+            if ticker in self.positions:
+                info = self.positions[ticker]
+                strategy_code = info.get("strategy", strategy_code)
+                risk_level = info.get("level", risk_level)
             avg_buy = float(b.get("avg_buy_price", 0))
             pnl = round((price - avg_buy) / avg_buy * 100, 1) if avg_buy else None
 

--- a/tests/test_positions.py
+++ b/tests/test_positions.py
@@ -1,0 +1,18 @@
+import pytest
+from bot.trader import UpbitTrader
+
+class DummyUpbit:
+    def get_balances(self):
+        return []
+
+
+def test_build_positions_uses_saved_strategy(monkeypatch):
+    conf = {"strategy": "M-BREAK", "level": "중도적", "params": {"sl": 0, "tp": 0}}
+    tr = UpbitTrader("k", "s", conf)
+    tr.upbit = DummyUpbit()
+    monkeypatch.setattr("pyupbit.get_current_price", lambda *a, **k: 1000.0)
+    balances = [{"currency": "BTC", "balance": "0.1", "avg_buy_price": "1000"}]
+    tr.positions["KRW-BTC"] = {"strategy": "EMA-STACK", "level": "공격적"}
+    result = tr.build_positions(balances)
+    assert result and result[0]["strategy"] == "EMA-STACK"
+    assert result[0]["level"] == "공격적"


### PR DESCRIPTION
## Summary
- show actual strategy per coin in trader positions
- test that build_positions uses saved strategy

## Testing
- `python -m pytest -q` *(fails: No module named pytest)*