### PR TITLE
Restrict new trades by existing positions

### DIFF
--- a/tests/test_trader_loop.py
+++ b/tests/test_trader_loop.py
@@ -33,3 +33,31 @@ def test_buy_market_order_uses_krw(monkeypatch):
     with pytest.raises(SystemExit):
         tr.run_loop()
     assert up.last == 10000
+
+
+def test_max_positions_blocks_new_buys(monkeypatch):
+    up = DummyUpbit()
+    conf = {"amount": 10000, "tickers": ["KRW-TEST"], "max_positions": 1}
+    tr = UpbitTrader("k", "s", conf)
+    tr.upbit = up
+    tr.positions["KRW-EXIST"] = {
+        "qty": 1,
+        "entry": 1000,
+        "strategy": "S",
+        "level": "중도적",
+    }
+
+    df = pd.DataFrame({"open": [1]*120, "high": [1]*120, "low": [1]*120,
+                        "close": [1000]*120, "volume": [1]*120})
+    monkeypatch.setattr("pyupbit.get_ohlcv", lambda *a, **k: df)
+    monkeypatch.setattr("bot.trader.calc_indicators", lambda d: d)
+    monkeypatch.setattr("bot.trader.calc_tis", lambda t: 100.0)
+    monkeypatch.setattr("bot.trader.df_to_market", lambda d, t: {})
+    monkeypatch.setattr("bot.trader.check_buy_signal", lambda s, l, m: True)
+    monkeypatch.setattr("bot.trader.check_sell_signal", lambda s, l, m: False)
+    monkeypatch.setattr("time.sleep", lambda x: (_ for _ in ()).throw(SystemExit()))
+
+    tr.running = True
+    with pytest.raises(SystemExit):
+        tr.run_loop()
+    assert up.last is None


### PR DESCRIPTION
## Summary
- load account balances when bot starts
- block new purchases when the number of held coins reaches the configured limit
- test that existing positions prevent additional buys

## Testing
- `pytest -q` *(fails: command not found)*