### PR TITLE
Keep tickers despite price lookup failures

### DIFF
--- a/README.md
+++ b/README.md
@@ -175,9 +175,9 @@ Example error:
 fails. Tests load this file to avoid network access.
 
 The bot tracks price lookup errors per coin. When a coin fails more than
-`failure_limit` times (default `3`), its ticker is removed from monitoring.
-After `retry_after` seconds (default `600`), the ticker is automatically
-restored.
+`failure_limit` times (default `3`), a warning is raised but the ticker remains
+monitored. The failure count is then reset so additional alerts may trigger if
+the problem continues.
 
 ## Documentation
 - `docs/OVERVIEW_KR.md` – 프로젝트 전체 흐름을 한국어로 정리한 문서

--- a/tests/test_account_summary.py
+++ b/tests/test_account_summary.py
@@ -6,19 +6,14 @@ class DummyUpbit:
         return [{"currency": "AAA", "balance": "2"}, {"currency": "KRW", "balance": "1000"}]
 
 
-def test_account_summary_skips_failed(monkeypatch):
+def test_account_summary_records_failure(monkeypatch):
     tr = UpbitTrader("k", "s", {})
     tr.upbit = DummyUpbit()
-    tr._failed_until["AAA"] = 9999999999
-
-    called = False
 
     def fake_price(*a, **k):
-        nonlocal called
-        called = True
-        return 500.0
+        raise Exception("fail")
 
     monkeypatch.setattr("pyupbit.get_current_price", fake_price)
     summary = tr.account_summary()
     assert summary == {"cash": 1000, "total": 1000, "pnl": 0.0}
-    assert called is False
+    assert tr._fail_counts.get("AAA") == 1

--- a/tests/test_trader_loop.py
+++ b/tests/test_trader_loop.py
@@ -35,18 +35,18 @@ def test_buy_market_order_uses_krw(monkeypatch):
     assert up.last == 10000
 
 
-def test_failure_limit_removes_ticker():
+def test_failure_limit_warns_but_keeps_ticker():
     tr = UpbitTrader("k", "s", {"tickers": ["KRW-AAA"], "failure_limit": 2})
     tr._record_price_failure("AAA")
     assert "KRW-AAA" in tr.tickers
     tr._record_price_failure("AAA")
-    assert "KRW-AAA" not in tr.tickers
+    assert "KRW-AAA" in tr.tickers
 
 
-def test_price_failure_removes_and_restores(monkeypatch):
-    tr = UpbitTrader("k", "s", {"tickers": ["KRW-AAA"], "failure_limit": 1, "retry_after": 1})
+def test_price_failure_does_not_remove_in_loop(monkeypatch):
+    tr = UpbitTrader("k", "s", {"tickers": ["KRW-AAA"], "failure_limit": 1})
     tr._record_price_failure("AAA")
-    assert "KRW-AAA" not in tr.tickers
+    assert "KRW-AAA" in tr.tickers
 
     class T:
         t = 0


### PR DESCRIPTION
## Summary
- keep monitoring tickers even if price lookup repeatedly fails
- just warn when `failure_limit` is exceeded and reset the counter
- simplify run loop and price fetch logic
- update tests for new behaviour
- document the new failure logic in README

## Testing
- `python3 -m pytest -q` *(fails: No module named pytest)*