### PR TITLE
Fix missing telegram trade alerts

### DIFF
--- a/bot/trader.py
+++ b/bot/trader.py
@@ -66,6 +66,15 @@ class UpbitTrader:
                 if self.logger:
                     self.logger.debug("telegram send failed")
 
+    def _notify(self, msg: str) -> None:
+        """일반 정보성 메시지를 텔레그램으로 전송한다."""
+        if self.token and self.chat:
+            try:
+                send_telegram(self.token, self.chat, msg)
+            except Exception:
+                if self.logger:
+                    self.logger.debug("telegram send failed")
+
     def _record_price_failure(self, currency: str) -> None:
         """시세 조회 실패 횟수를 누적하고 경고만 전송한다."""
         count = self._fail_counts.get(currency, 0) + 1
@@ -221,6 +230,9 @@ class UpbitTrader:
                                 qty,
                                 chosen,
                             )
+                        self._notify(
+                            f"[BUY] {ticker} {qty:.4f}개 @ {last_price:,.1f}원"
+                        )
 
                 # 매도 신호 확인
                 for ticker, pos in list(self.positions.items()):
@@ -250,6 +262,9 @@ class UpbitTrader:
                                 pos["qty"],
                                 pos["strategy"],
                             )
+                        self._notify(
+                            f"[SELL] {ticker} {pos['qty']:.4f}개 @ {df_ind['Close'].iloc[-1]:,.1f}원"
+                        )
                         self.positions.pop(ticker, None)
                 time.sleep(300)  # 5분 대기 후 다음 루프
                 error_count = 0

--- a/tests/test_notifications.py
+++ b/tests/test_notifications.py
@@ -1,0 +1,34 @@
+import pandas as pd
+import pytest
+from bot.trader import UpbitTrader
+
+class DummyUpbit:
+    def __init__(self):
+        self.last=None
+    def get_balances(self):
+        return []
+    def buy_market_order(self,ticker,amount):
+        self.last=amount
+        return {"price":1000.0,"volume":amount/1000.0}
+    def sell_market_order(self,ticker,qty):
+        return {}
+
+def test_buy_triggers_notification(monkeypatch):
+    up=DummyUpbit()
+    conf={"amount":10000,"tickers":["KRW-TST"]}
+    tr=UpbitTrader("k","s",conf)
+    tr.upbit=up
+    df=pd.DataFrame({"open":[1]*120,"high":[1]*120,"low":[1]*120,"close":[1000]*120,"volume":[1]*120})
+    monkeypatch.setattr("pyupbit.get_ohlcv",lambda *a,**k:df)
+    monkeypatch.setattr("bot.trader.calc_indicators",lambda d:d)
+    monkeypatch.setattr("bot.trader.calc_tis",lambda t:100.0)
+    monkeypatch.setattr("bot.trader.df_to_market",lambda d,t:{})
+    monkeypatch.setattr("bot.trader.check_buy_signal",lambda s,l,m:True)
+    monkeypatch.setattr("bot.trader.check_sell_signal",lambda s,l,m:False)
+    sent={}
+    monkeypatch.setattr(tr,"_notify",lambda msg:sent.setdefault("msg",msg))
+    monkeypatch.setattr("time.sleep",lambda x:(_ for _ in ()).throw(SystemExit))
+    tr.running=True
+    with pytest.raises(SystemExit):
+        tr.run_loop()
+    assert sent.get("msg","" ).startswith("[BUY]")


### PR DESCRIPTION
## Summary
- add `_notify` helper in `bot/trader.py`
- send a telegram message after each buy/sell trade
- add regression test

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'bot')*