### PR TITLE
Default strategy INIT

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,6 +36,7 @@ are filled with server side data.
 - **static/css/custom.css** – Consolidated styles for all pages with no inline styles left in templates.
 - **config/market.json** – Sample market data loaded for monitoring filters.
 - **config/active_positions.json** – Persisted open trades restored on startup.
+  Missing strategy information results in a strategy code of `INIT`, meaning the trade's origin is unknown.
 - **notify()** – Helper in `app.py` that sends messages to SocketIO and Telegram.
 
 ## Example variables passed to templates
@@ -172,7 +173,8 @@ Example error:
 [ERROR] Missing required secrets: UPBIT_KEY, UPBIT_SECRET
 ```
 
-`config/market.json` stores fallback market data when live fetching from Upbit fails. Tests load this file to avoid network access.
+`config/market.json` stores fallback market data when live fetching from Upbit fails.
+Tests load this file to avoid network access.
 `config/active_positions.json` keeps track of open positions so strategies are restored on startup.
 
 The bot tracks price lookup errors per coin. When a coin fails more than

--- a/bot/trader.py
+++ b/bot/trader.py
@@ -424,7 +424,8 @@ class UpbitTrader:
         params = self.config.get("params", {})
         sl_pct = params.get("sl", 0) * 100
         tp_pct = params.get("tp", 0) * 100
-        default_strategy = self.config.get("strategy", "-")
+        # 기본 전략값이 없으면 원인 불명 포지션으로 간주한다
+        default_strategy = "INIT"
         default_level = self.config.get("level", "중도적")
         for b in balances:
             currency = b.get("currency")

--- a/tests/test_positions.py
+++ b/tests/test_positions.py
@@ -18,6 +18,16 @@ def test_build_positions_uses_saved_strategy(monkeypatch):
     assert result[0]["level"] == "공격적"
 
 
+def test_build_positions_default_strategy(monkeypatch):
+    conf = {"level": "중도적", "params": {"sl": 0, "tp": 0}}
+    tr = UpbitTrader("k", "s", conf)
+    tr.upbit = DummyUpbit()
+    monkeypatch.setattr("pyupbit.get_current_price", lambda *a, **k: 1000.0)
+    balances = [{"currency": "ETH", "balance": "0.1", "avg_buy_price": "1000"}]
+    result = tr.build_positions(balances)
+    assert result and result[0]["strategy"] == "INIT"
+
+
 def test_build_positions_records_failure(monkeypatch):
     conf = {}
     tr = UpbitTrader("k", "s", conf)


### PR DESCRIPTION
## Notes
- used `INIT` as the fallback strategy when building a position
- documented that missing strategy info means trade origin is unknown
- added regression test for default strategy

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'pandas')*