### PR TITLE
Retry Upbit API requests on header parse error

### DIFF
--- a/bot/trader.py
+++ b/bot/trader.py
@@ -331,7 +331,12 @@ class UpbitTrader:
         try:
             if self.logger:
                 self.logger.debug("Fetching balances from Upbit")
-            return call_upbit_api(self.upbit.get_balances)
+            data = call_upbit_api(self.upbit.get_balances)
+            if isinstance(data, str):
+                if self.logger:
+                    self.logger.warning("Unexpected response for balances: %s", data)
+                return None
+            return data
         except Exception as e:
             if self.logger:
                 self.logger.exception("Failed to get balances: %s", e)

--- a/utils.py
+++ b/utils.py
@@ -59,20 +59,44 @@ class RateLimiter:
 _RATE_LIMITER = RateLimiter(7, 1.0)
 
 
-def call_upbit_api(func, *args, **kwargs):
-    """Call Upbit API function with global rate limiting."""
-    _RATE_LIMITER.acquire()
+def _patch_pyupbit_parser() -> None:
+    """Replace pyupbit's Remaining-Req parser with a tolerant version."""
     try:
-        return func(*args, **kwargs)
-    except Exception as exc:  # noqa: BLE001 - pyupbit custom error
-        # pyupbit 1.x raises RemainingReqParsingError when the header is missing.
-        # Retry once in that case so caller doesn't immediately fail.
-        if exc.__class__.__name__ == "RemainingReqParsingError":
-            logging.getLogger(__name__).warning(
-                "Remaining-Req header parse failed, retrying"  # noqa: TRY003
-            )
+        from pyupbit import request_api
+    except Exception:  # pragma: no cover - optional dependency
+        return
+
+    original = getattr(request_api, "_parse", None)
+
+    def _safe_parse(header: str):
+        try:
+            if original:
+                return original(header)
+        except Exception:  # noqa: BLE001 - pyupbit custom error
+            pass
+        return 0
+
+    request_api._parse = _safe_parse
+
+
+def call_upbit_api(func, *args, retries: int = 2, delay: float = 0.2, **kwargs):
+    """Call Upbit API function with global rate limiting and retry logic."""
+    for attempt in range(retries + 1):
+        _RATE_LIMITER.acquire()
+        try:
             return func(*args, **kwargs)
-        raise
+        except Exception as exc:  # noqa: BLE001 - pyupbit custom error
+            if exc.__class__.__name__ == "RemainingReqParsingError":
+                logging.getLogger(__name__).warning(
+                    "Remaining-Req header parse failed, retry %s/%s", attempt + 1, retries
+                )
+                if attempt == 0:
+                    _patch_pyupbit_parser()
+                if attempt < retries:
+                    time.sleep(delay)
+                    delay *= 2
+                    continue
+            raise
 
 
 class LevelFilter(logging.Filter):


### PR DESCRIPTION
## Summary
- add retry loop to `call_upbit_api`
- patch pyupbit parser on failure
- guard `get_balances` return type

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'bot', etc.)*
