### PR TITLE
Handle invalid access key gracefully

### DIFF
--- a/bot/trader.py
+++ b/bot/trader.py
@@ -333,8 +333,18 @@ class UpbitTrader:
                 self.logger.debug("Fetching balances from Upbit")
             data = call_upbit_api(self.upbit.get_balances)
             if not isinstance(data, list):
-                if self.logger:
-                    self.logger.warning("Unexpected response for balances: %s", data)
+                if isinstance(data, dict) and data.get("error", {}).get("name"):
+                    if self.logger:
+                        self.logger.warning(
+                            "Balances API error: %s", data["error"].get("name")
+                        )
+                    if data["error"].get("name") == "invalid_access_key":
+                        self._alert("[ERROR] 업비트 API 키가 잘못되었습니다.")
+                else:
+                    if self.logger:
+                        self.logger.warning(
+                            "Unexpected response for balances: %s", data
+                        )
                 return None
             # Filter out invalid entries to avoid type errors
             result = [b for b in data if isinstance(b, dict)]

--- a/tests/test_account_summary.py
+++ b/tests/test_account_summary.py
@@ -22,3 +22,14 @@ def test_account_summary_records_failure(monkeypatch):
         "pnl": 0.0,
     }
     assert tr._fail_counts.get("AAA") == 1
+
+
+def test_account_summary_invalid_key(monkeypatch):
+    class ErrUpbit:
+        def get_balances(self):
+            return {"error": {"name": "invalid_access_key"}}
+
+    tr = UpbitTrader("k", "s", {})
+    tr.upbit = ErrUpbit()
+    summary = tr.account_summary()
+    assert summary is None


### PR DESCRIPTION
## Summary
- catch invalid access key error in `get_balances`
- add regression test for invalid access key response

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'bot')*