### PR TITLE
Enable saving monitoring coin filters via API

### DIFF
--- a/templates/00_base.html
+++ b/templates/00_base.html
@@ -91,19 +91,43 @@
       }
     }
     function openMonitorModal() {
-      document.getElementById("monitorModal").classList.remove("hidden");
+      fetch('/api/universe_config')
+        .then(r => r.json())
+        .then(cfg => {
+          document.getElementById('minPrice').value = cfg.min_price;
+          document.getElementById('maxPrice').value = cfg.max_price;
+          document.getElementById('minVolatility').value = cfg.min_volatility;
+          document.getElementById('volumeRank').value = cfg.volume_rank;
+          document.getElementById("monitorModal").classList.remove("hidden");
+        })
+        .catch(() => {
+          document.getElementById("monitorModal").classList.remove("hidden");
+        });
     }
     function closeMonitorModal() {
       document.getElementById("monitorModal").classList.add("hidden");
     }
     function saveMonitorCondition() {
-      var minPrice = document.getElementById("minPrice").value;
-      var maxPrice = document.getElementById("maxPrice").value;
-      var minVolatility = document.getElementById("minVolatility").value;
-      var volumeRank = document.getElementById("volumeRank").value;
-      alert("저장 완료!\n\n최소 가격: " + minPrice + "\n최대 가격: " + maxPrice +
-            "\n변동성 하한: " + minVolatility + "%\n거래대금 순위: Top " + volumeRank);
-      closeMonitorModal();
+      var minPrice = parseFloat(document.getElementById("minPrice").value);
+      var maxPrice = parseFloat(document.getElementById("maxPrice").value);
+      var minVolatility = parseFloat(document.getElementById("minVolatility").value);
+      var volumeRank = parseInt(document.getElementById("volumeRank").value);
+      fetch('/api/universe_config', {
+        method: 'POST',
+        headers: {'Content-Type': 'application/json'},
+        body: JSON.stringify({
+          min_price: minPrice,
+          max_price: maxPrice,
+          min_volatility: minVolatility,
+          volume_rank: volumeRank
+        })
+      })
+        .then(r => r.json())
+        .then(() => {
+          closeMonitorModal();
+          location.reload();
+        })
+        .catch(console.error);
     }
     document.addEventListener('keydown', function(e) {
       if (e.key === "Escape") closeMonitorModal();

--- a/templates/01_Home.html
+++ b/templates/01_Home.html
@@ -187,28 +187,28 @@
           <input type="number" step="0.1" min="0" id="minPrice"
                  class="w-full px-3 py-2 rounded bg-gray-900 border border-gray-700 text-white"
                  class="focus:outline-none focus:border-green-400"
-                 value="700.0">
+                 value="{{ config.min_price }}">
         </div>
         <div class="mb-3">
           <label class="input-label block mb-1">최대 가격(원)</label>
           <input type="number" step="0.1" min="0" id="maxPrice"
                  class="w-full px-3 py-2 rounded bg-gray-900 border border-gray-700 text-white"
                  class="focus:outline-none focus:border-green-400"
-                 value="23000.0">
+                 value="{{ config.max_price }}">
         </div>
         <div class="mb-3">
           <label class="input-label block mb-1">변동성 하한(%)</label>
           <input type="number" step="0.01" min="0" max="100" id="minVolatility"
                  class="w-full px-3 py-2 rounded bg-gray-900 border border-gray-700 text-white"
                  class="focus:outline-none focus:border-green-400"
-                 value="1.5">
+                 value="{{ config.min_volatility }}">
         </div>
         <div class="mb-5">
           <label class="input-label block mb-1">24h 거래대금 순위(Top N)</label>
           <input type="number" min="1" max="50" id="volumeRank"
                  class="w-full px-3 py-2 rounded bg-gray-900 border border-gray-700 text-white"
                  class="focus:outline-none focus:border-green-400"
-                 value="30">
+                 value="{{ config.volume_rank }}">
         </div>
         <div class="flex gap-2">
           <button type="button" onclick="closeMonitorModal()"


### PR DESCRIPTION
## Summary
- add API endpoint to load and save monitoring coin filter
- show latest config values in the modal
- update JS modal handling to fetch and save settings
- pass config to dashboard template

## Testing
- `python -m py_compile app.py f1_universe.py`