### PR TITLE
Remove KRW prefix in ticker display

### DIFF
--- a/templates/01_Home.html
+++ b/templates/01_Home.html
@@ -37,7 +37,7 @@
       <div class="flex flex-wrap gap-2 mt-2 mb-1">
         {% for ticker in universe %}
         <span class="inline-block w-8 h-8 rounded-full bg-green-400 text-xs flex items-center justify-center font-bold">
-          {{ ticker }}
+          {{ ticker.replace('KRW-', '') }}
         </span>
         {% endfor %}
       </div>

--- a/templates/index.html
+++ b/templates/index.html
@@ -4,7 +4,7 @@
 <h1 class="text-xl font-bold mb-4">Selected Universe</h1>
 <ul class="list-disc pl-5">
   {% for ticker in universe %}
-  <li>{{ ticker }}</li>
+  <li>{{ ticker.replace('KRW-', '') }}</li>
   {% endfor %}
 </ul>
 {% endblock %}


### PR DESCRIPTION
## Summary
- drop `KRW-` prefix when rendering tickers

## Testing
- `python -m py_compile app.py f1_universe.py`