### PR TITLE
Unify styles with home page

### DIFF
--- a/templates/02_Strategy.html
+++ b/templates/02_Strategy.html
@@ -3,12 +3,13 @@
 {% block head_extra %}
   <style>
     :root {
-      --main-bg: #1a202a;
-      --card-bg: #212733;
-      --header-bg: #232b35;
-      --table-bg: #232832;
-      --input-bg: #181e25;
-      --input-border: #293043;
+      /* Use the same palette as the home page */
+      --main-bg: #222831;
+      --card-bg: #1f2937;
+      --header-bg: #334155;
+      --table-bg: #1f2937;
+      --input-bg: #0f172a;
+      --input-border: #374151;
       --green: #22c55e;
       --green-light: #4ade80;
       --white: #e5e7eb;
@@ -17,31 +18,26 @@
       --shadow: 0 2px 20px #0005;
       --radius: 18px;
     }
-    body {
-      background: var(--main-bg);
-      color: var(--white);
-      font-family: 'Pretendard','Noto Sans KR',sans-serif;
-      font-size: 1.05rem;
-      letter-spacing: -0.2px;
-    }
+    /* Use the base template's body styles for consistency */
     .main-wrap {
-      max-width: 1160px; margin: 44px auto 0 auto;
+      max-width: 1160px;
+      margin: 32px auto 0 auto;
       background: var(--card-bg);
       border-radius: var(--radius);
-      box-shadow: var(--shadow);
-      padding: 36px 36px 44px 36px;
-      border: 1.3px solid var(--header-bg);
+      box-shadow: 0 1px 4px #0006;
+      padding: 32px;
+      border: 1px solid var(--header-bg);
     }
     .title-bar {
-      display: flex; align-items: center; gap: 16px; margin-bottom: 22px;
-      padding-bottom: 10px; border-bottom: 1.3px solid #3ba27240;
+      display: flex;
+      align-items: center;
+      gap: 16px;
+      margin-bottom: 22px;
     }
     .title-icon {
-      background: var(--header-bg);
-      color: var(--green); border-radius: 8px; padding: 10px 24px;
-      font-size: 1.16rem; font-weight: 900; letter-spacing: -1px;
-      box-shadow: 0 1px 7px #22c55e2c;
-      border: 1.2px solid var(--green);
+      font-size: 1.25rem;
+      font-weight: 700;
+      color: var(--white);
     }
     .toggle-all { margin-right: 14px; }
     .last-saved { color: var(--muted); font-size: 0.96rem; margin-left: 10px;}

--- a/templates/03_Risk.html
+++ b/templates/03_Risk.html
@@ -5,11 +5,8 @@
     html, body {
       width: 100vw;
       height: 100vh;
-      background: #181e25;
     }
     body {
-      min-width: 1920px;
-      min-height: 1080px;
       overflow-x: auto;
     }
     .main-wrap {
@@ -17,22 +14,22 @@
       margin: 0 auto;
     }
     .section-card {
-      background: #232b35;
-      border-radius: 20px;
-      box-shadow: 0 1px 16px #0004;
-      padding: 2.8rem 2.8rem 2.2rem 2.8rem;
+      background: #1f2937;
+      border-radius: 18px;
+      box-shadow: 0 1px 4px #0006;
+      padding: 2rem;
       margin-bottom: 44px;
     }
     .card-title {
       font-weight: 700;
-      font-size: 1.55rem;
+      font-size: 1.25rem;
       letter-spacing: -0.5px;
     }
     .input-label {
-      font-size: 1.22rem;
+      font-size: 1rem;
       color: #cbd5e1;
       font-weight: 500;
-      margin-bottom: 11px;
+      margin-bottom: 8px;
     }
     .risk-grid {
       display: grid;
@@ -45,16 +42,16 @@
     }
     .input-xl,
     .select-xl {
-      background: #161b22;
-      border: 2px solid #394150;
+      background: #0f172a;
+      border: 2px solid #374151;
       color: #fff;
-      font-size: 1.27rem;
-      border-radius: 13px;
+      font-size: 1rem;
+      border-radius: 10px;
       width: 100%;
       font-family: inherit;
       box-sizing: border-box;
-      padding: 18px 24px 18px 16px;
-      height: 60px; /* select 높이 통일 */
+      padding: 14px 16px;
+      height: 48px; /* select 높이 통일 */
       outline: none;
       transition: border 0.15s;
       line-height: 1.25;
@@ -79,20 +76,20 @@
       margin-top: 12px;
     }
     .btn-save {
-      background: #15803d;
-      color: #fff;
-      font-weight: 600;
+      background: #22c55e;
+      color: #15212b;
+      font-weight: 700;
     }
     .btn-save:hover {
-      background: #166534;
+      background: #4ade80;
     }
     .btn-restore {
-      background: #64748b;
+      background: #475569;
       color: #fff;
       font-weight: 600;
     }
     .btn-restore:hover {
-      background: #475569;
+      background: #334155;
     }
     .btn-reset {
       background: #374151;
@@ -134,7 +131,7 @@
       left: 50%;
       top: 50%;
       transform: translate(-50%, -50%);
-      background: #232b35;
+      background: #1f2937;
       border-radius: 17px;
       box-shadow: 0 8px 32px #000a;
       width: 460px;
@@ -162,7 +159,7 @@
       font-size: 1.21rem;
     }
     .modal-table th {
-      background: #222b36;
+      background: #334155;
       font-weight: 600;
     }
     .modal-actions {
@@ -188,7 +185,6 @@
       }
     }
   </style>
-</style>
 {% endblock %}
 {% block content %}
   <div class="main-wrap py-16">
@@ -473,7 +469,7 @@
       else if (mode === '원복') after = yday[card];
       else if (mode === '초기화') after = init[card];
       let content = `<table class="modal-table mx-auto">
-        <tr style="background:#222b36;">
+        <tr style="background:#334155;">
           <th>항목</th><th>이전값</th><th>변경될 값</th>
         </tr>`;
       for (let i = 0; i < ids.length; i++) {

--- a/templates/04_Analysis.html
+++ b/templates/04_Analysis.html
@@ -2,11 +2,10 @@
 {% block title %}AUTO UPBIT KPI/Stats Explorer{% endblock %}
 {% block head_extra %}
 <style>
-  body { background: linear-gradient(135deg,#222831 65%,#1a232e 100%); color: #e5e7eb; }
-  .main-wrap { max-width: 1200px; margin: 44px auto 0 auto; border-radius: 18px; background: #232b35; box-shadow: 0 2px 24px #0009; padding: 39px 35px 48px 35px; }
-  .section-title { font-size: 1.5rem; font-weight: 900; color: #38bdf8; letter-spacing: -1px; margin-bottom: 18px; }
+  .main-wrap { max-width: 1200px; margin: 32px auto 0 auto; border-radius: 18px; background: #1f2937; box-shadow: 0 1px 4px #0006; padding: 32px; }
+  .section-title { font-size: 1.25rem; font-weight: 700; color: #e5e7eb; margin-bottom: 18px; }
   .pivotbar { display: flex; flex-wrap: wrap; gap: 20px; margin-bottom: 28px; align-items: center; }
-  .dropdown, .inp-date, .inp-txt { background: #181e25; border: 1.5px solid #334155aa; color: #bae6fd; border-radius: 7px; padding: 7px 12px; font-size: 1.03rem; }
+  .dropdown, .inp-date, .inp-txt { background: #0f172a; border: 1.5px solid #374151; color: #e5e7eb; border-radius: 7px; padding: 7px 12px; font-size: 1rem; }
   .dropdown:focus, .inp-date:focus, .inp-txt:focus { outline: none; border-color: #22c55e; }
   .inp-date { width: 130px; }
   .inp-txt { width: 140px; }
@@ -16,14 +15,14 @@
   .btn-excel:hover { background: #22c55e; color: #153926; }
   table { width: 100%; border-collapse: separate; border-spacing: 0 7px; margin-bottom: 18px; }
   th, td { padding: 11px 8px; text-align: center; }
-  th { background: #202733; color: #38bdf8; font-weight: 900; }
-  tr { background: #242c38; }
+  th { background: #334155; color: #e5e7eb; font-weight: 700; }
+  tr { background: #1f2937; }
   tr:hover { background: #334155; }
-  .chart, .chart2, .chart3 { background: #1a232e; border-radius: 12px; height: 200px; margin-bottom: 18px; display: flex; align-items: center; justify-content: center; color: #4ade80; font-weight: 900; font-size: 1.11rem; }
+  .chart, .chart2, .chart3 { background: #111827; border-radius: 12px; height: 200px; margin-bottom: 18px; display: flex; align-items: center; justify-content: center; color: #4ade80; font-weight: 900; font-size: 1.11rem; }
   .sub-title { font-size: 1.13rem; color: #4ade80; font-weight: 800; margin-top: 20px; margin-bottom: 8px; }
-  .desc { color: #b6bccf; font-size: 1.01rem; margin-bottom: 6px; }
+  .desc { color: #cbd5e1; font-size: 1rem; margin-bottom: 6px; }
   .tag-green { background: #22c55e; color: #1a3a23; font-size: 0.92rem; border-radius: 6px; padding: 2px 11px; margin-left: 8px; }
-  .tag-blue { background: #38bdf8; color: #123548; font-size: 0.92rem; border-radius: 6px; padding: 2px 11px; margin-left: 8px; }
+  .tag-blue { background: #3b82f6; color: #123548; font-size: 0.92rem; border-radius: 6px; padding: 2px 11px; margin-left: 8px; }
   @media (max-width: 1200px) { .main-wrap { max-width: 99vw; padding: 9px 2vw; } }
 </style>
 {% endblock %}

--- a/templates/05_pSettings.html
+++ b/templates/05_pSettings.html
@@ -2,24 +2,23 @@
 {% block title %}개인설정 - AUTO UPBIT{% endblock %}
 {% block head_extra %}
   <style>
-    body { background: #181e25; min-width:1200px; }
     .box {
-      background:#232b35;
+      background:#1f2937;
       border-radius:18px;
-      box-shadow:0 1px 16px #0004;
-      padding:2.2rem 2.2rem 1.6rem 2.2rem;
+      box-shadow:0 1px 4px #0006;
+      padding:2rem;
       margin-bottom:34px;
       max-width:780px;
       margin-left:auto;
       margin-right:auto;
     }
-    .box-title { font-weight:700; font-size:1.3rem; margin-bottom:20px; color:#fff; }
+    .box-title { font-weight:700; font-size:1.25rem; margin-bottom:20px; color:#fff; }
     .label { font-size:1.1rem; color:#cbd5e1; font-weight:500; margin-bottom:7px; }
     .input {
-      background:#161b22;
-      border:2px solid #394150;
+      background:#0f172a;
+      border:2px solid #374151;
       color:#fff;
-      font-size:1.15rem;
+      font-size:1rem;
       border-radius:10px;
       width:100%;
       padding:14px 16px;
@@ -29,14 +28,14 @@
     .row { display:grid; grid-template-columns:1fr 1fr; gap:36px 32px; }
     .box-btns { text-align:right; margin-top: 6px; }
     .btn-main {
-      background:#15803d;
-      color:#fff;
-      font-weight:600;
+      background:#22c55e;
+      color:#15212b;
+      font-weight:700;
       border-radius:11px;
       padding:12px 38px;
       margin-left:7px;
     }
-    .btn-main:hover { background:#166534; }
+    .btn-main:hover { background:#4ade80; }
     .alarm-row { display:grid; grid-template-columns:1fr 1fr; gap:20px 22px; }
     .switch { position: relative; display: inline-block; width: 48px; height: 28px; }
     .switch input { opacity:0; width:0; height:0; }
@@ -67,8 +66,8 @@
     .desc { color:#6ee7b7; font-size:0.98rem; margin-bottom:12px; }
     .timepicker-wrap { display:flex; align-items:center; gap:6px; margin-bottom:0; }
     .timepicker-box {
-      background:#161b22;
-      border:2px solid #394150;
+      background:#0f172a;
+      border:2px solid #374151;
       color:#fff;
       border-radius:10px;
       font-size:1.11rem;


### PR DESCRIPTION
## Summary
- soften strategy page header and use dashboard palette
- shrink risk cards and inputs to match home styling
- restyle analysis sections with darker tables and headings
- update personal settings boxes and buttons for consistency

## Testing
- `pytest -q`