### PR TITLE
Persist universe between runs

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,0 +1,10 @@
+# UPBIT AutoTrader HS
+
+This project contains utilities for building a trading universe and evaluating trading signals.
+
+## Universe cache
+
+The latest selected trading universe is saved to `config/current_universe.json`. It is written by `f1_universe.update_universe()` and loaded on startup via `load_universe_from_file()`.
+
+External processes such as `signal_loop.py` can use this file to share the same universe.
+

--- a/app.py
+++ b/app.py
@@ -11,12 +11,14 @@ from f1_universe import (
     get_universe,
     schedule_universe_updates,
     update_universe,
+    load_universe_from_file,
     CONFIG_PATH,
 )
 
 app = Flask(__name__)
 
 CONFIG = load_config()
+load_universe_from_file()
 schedule_universe_updates(1800, CONFIG)
 
 

--- a/signal_loop.py
+++ b/signal_loop.py
@@ -4,7 +4,13 @@ from typing import Optional
 
 import pyupbit
 
-from f1_universe import get_universe, load_config, select_universe, schedule_universe_updates
+from f1_universe import (
+    get_universe,
+    load_config,
+    select_universe,
+    schedule_universe_updates,
+    load_universe_from_file,
+)
 from f2_signal import f2_signal
 
 
@@ -37,6 +43,7 @@ def process_symbol(symbol: str) -> Optional[dict]:
 def main_loop(interval: int = 30) -> None:
     """Main processing loop fetching the universe and evaluating signals."""
     cfg = load_config()
+    load_universe_from_file()
     schedule_universe_updates(1800, cfg)
     while True:
         universe = get_universe()
@@ -60,4 +67,5 @@ if __name__ == "__main__":
             logging.StreamHandler(),
         ],
     )
+    load_universe_from_file()
     main_loop()


### PR DESCRIPTION
## Summary
- write the current universe to `config/current_universe.json` whenever it is updated
- load this cached universe at startup with `load_universe_from_file`
- make `get_universe` fall back to the cached file
- initialize the universe cache in `signal_loop.py` and `app.py`
- document the cache file in a new README

## Testing
- `pytest -q`