### PR TITLE
Revise strategy page layout

### DIFF
--- a/templates/02_Strategy.html
+++ b/templates/02_Strategy.html
@@ -118,6 +118,38 @@
       min-width: 140px; max-width: 320px; text-align: left;
     }
     tr:hover .tooltip { display: block; }
+    .modal-bg {
+      position: fixed;
+      z-index: 99;
+      left: 0;
+      top: 0;
+      width: 100vw;
+      height: 100vh;
+      background: rgba(10, 16, 20, 0.65);
+    }
+    .modal {
+      position: fixed;
+      z-index: 100;
+      left: 50%;
+      top: 50%;
+      transform: translate(-50%, -50%);
+      background: #1f2937;
+      border-radius: 17px;
+      box-shadow: 0 8px 32px #000a;
+      width: 600px;
+      max-width: 98vw;
+    }
+    .modal-title {
+      font-size: 1.2rem;
+      font-weight: 700;
+      color: #fff;
+      margin: 24px 0 12px 0;
+      text-align: center;
+    }
+    .modal-table { width:100%; margin:20px 0; }
+    .modal-table th { background:#334155; font-weight:600; padding:8px; }
+    .modal-table td { padding:8px; text-align:center; }
+    .modal-actions { text-align:center; margin-bottom:20px; }
     @media (max-width:1050px) { .main-wrap { max-width: 99vw; padding: 10px 2vw;}
       th, td { font-size: 0.98rem; }
       .dropdown, .order-inp { width: 78px; font-size: 0.97rem; }
@@ -134,126 +166,112 @@
         <span class="onoff-slider"></span>
       </label>
       <span style="color:var(--green); font-weight:700;">전체 ON</span>
-      <div class="flex gap-2 items-center ml-6">
-        <span class="text-sm text-gray-300 mr-1">전체 매수조건</span>
-        <select id="all-buy" class="dropdown">
-          <option>공격적</option>
-          <option>중도적</option>
-          <option selected>보수적</option>
-        </select>
-        <span class="text-sm text-gray-300 mr-1 ml-6">전체 매도조건</span>
-        <select id="all-sell" class="dropdown">
-          <option>공격적</option>
-          <option>중도적</option>
-          <option selected>보수적(짧게)</option>
-        </select>
-        <button class="btn-outline" onclick="applyAllSettings()">전체 적용</button>
-      </div>
-      <span class="last-saved ml-7">마지막 저장: 2025. 5. 23. 오후 5:59:58</span>
-      <button class="btn-outline ml-3" onclick="resetDefaults()">기본값 복원</button>
+      <span class="last-saved ml-6">마지막 저장: 2025. 5. 23. 오후 5:59:58</span>
+      <button class="btn-outline ml-4" onclick="openWinrateModal()">승률 데이터</button>
+      <button class="btn-outline ml-2" onclick="resetDefaults()">기본값 복원</button>
+      <button class="btn-outline ml-2" onclick="restoreYesterday()">어제값 복원</button>
       <button class="btn ml-2" onclick="alert('설정이 저장되었습니다!')">저장</button>
     </div>
     <table>
       <thead>
         <tr>
-          <th>ON/OFF</th>
-          <th>전략명</th>
-          <th>매수 조건</th>
-          <th>매도 조건</th>
-          <th>우선순위</th>
-          <th></th>
+          <th rowspan="2">ON/OFF</th>
+          <th rowspan="2">전략명</th>
+          <th rowspan="2">우선순위</th>
+          <th colspan="3">24시간 (실거래)</th>
+          <th colspan="3">분석 예상 결과</th>
+          <th rowspan="2">데이터 적용 값</th>
+        </tr>
+        <tr>
+          <th>거래 건수</th><th>승률</th><th>수익률</th>
+          <th>거래 건수</th><th>승률</th><th>수익률</th>
         </tr>
       </thead>
       <tbody id="tbl-body"></tbody>
-    </table>
-  </div>
+      </table>
+      <div id="win-modal-bg" class="modal-bg" style="display:none;"></div>
+      <div id="win-modal" class="modal" style="display:none;">
+        <div class="modal-title">승률 데이터</div>
+        <table class="modal-table mx-auto">
+          <tr>
+            <th colspan="3">YYYYMMDD-ML Best#1</th>
+            <th colspan="3">YYYYMMDD-ML Best#2</th>
+            <th colspan="3">YYYYMMDD-ML Best#3</th>
+          </tr>
+          <tr>
+            <th>전략명</th><th>거래건수</th><th>승률</th>
+            <th>전략명</th><th>거래건수</th><th>승률</th>
+            <th>전략명</th><th>거래건수</th><th>승률</th>
+          </tr>
+          <tr>
+            <td>M-BREAK</td><td>0</td><td>0%</td>
+            <td>M-BREAK</td><td>0</td><td>0%</td>
+            <td>M-BREAK</td><td>0</td><td>0%</td>
+          </tr>
+        </table>
+        <div class="modal-actions">
+          <button class="btn-outline" onclick="closeWinrateModal()">닫기</button>
+        </div>
+      </div>
+    </div>
 {% endblock %}
 {% block scripts %}
   <script>
-    const buyLevels = ["공격적", "중도적", "보수적"];
-    const sellLevels = ["공격적", "중도적", "보수적(짧게)"];
-
-    // 22개 전략 (실전 예시, 모두 보수적으로 기본값 셋팅)
     const strategies = [
-      {name:"M-BREAK", info:"고변동·거래량 급증 시 20봉 최고가 돌파", on:true, buy:"보수적", sell:"보수적(짧게)", order:1},
-      {name:"P-PULL", info:"상승 추세 중 단기 조정 진입", on:true, buy:"보수적", sell:"보수적(짧게)", order:2},
-      {name:"T-FLOW", info:"강한 상승 추세 지속 종목 매수", on:true, buy:"보수적", sell:"보수적(짧게)", order:3},
-      {name:"G-REV", info:"장기 하락 후 저점 부근 반전 매수", on:true, buy:"보수적", sell:"보수적(짧게)", order:4},
-      {name:"VOL-BRK", info:"거래량 급증, 신고가 부근 상승 포착", on:true, buy:"보수적", sell:"보수적(짧게)", order:5},
-      {name:"EMA-STACK", info:"EMA 상승 정배열+단기 조정 매수", on:true, buy:"보수적", sell:"보수적(짧게)", order:6},
-      {name:"VWAP-BNC", info:"VWAP 지지 반등", on:true, buy:"보수적", sell:"보수적(짧게)", order:7},
-      {name:"B-BAND", info:"볼린저 하단 이탈→재진입 반등", on:true, buy:"보수적", sell:"보수적(짧게)", order:8},
-      {name:"BB-SQZ", info:"밴드 폭 축소+거래급증 돌파", on:true, buy:"보수적", sell:"보수적(짧게)", order:9},
-      {name:"T-PULL", info:"추세 중 눌림목 반등 매수", on:true, buy:"보수적", sell:"보수적(짧게)", order:10},
-      {name:"RSI-BOUNCE", info:"RSI 과매도→반등 매수", on:true, buy:"보수적", sell:"보수적(짧게)", order:11},
-      {name:"BOLL-B", info:"볼린저 밴드 상단 돌파 매수", on:true, buy:"보수적", sell:"보수적(짧게)", order:12},
-      {name:"BB-SQZ", info:"밴드 폭 축소+거래급증 돌파", on:true, buy:"보수적", sell:"보수적(짧게)", order:13},
-      {name:"G-CROSS", info:"EMA 골든크로스+저항 돌파", on:true, buy:"보수적", sell:"보수적(짧게)", order:14},
-      {name:"ATR-EXPLODE", info:"ATR 급등+추세전환", on:true, buy:"보수적", sell:"보수적(짧게)", order:15},
-      {name:"MACD-MOM", info:"MACD GC+히스토그램 상승", on:true, buy:"보수적", sell:"보수적(짧게)", order:16},
-      {name:"STOCH-BOUNCE", info:"Stoch 과매도+GC 반등", on:true, buy:"보수적", sell:"보수적(짧게)", order:17},
-      {name:"RSI-DIV", info:"RSI 다이버전스+양봉", on:true, buy:"보수적", sell:"보수적(짧게)", order:18},
-      {name:"I-BREAK", info:"일목균형 구름 돌파", on:true, buy:"보수적", sell:"보수적(짧게)", order:19},
-      {name:"ADX-TRND", info:"ADX/DMI 상승 추세 진입", on:true, buy:"보수적", sell:"보수적(짧게)", order:20},
-      {name:"SAR-REV", info:"PSAR 반전 신호 매수", on:true, buy:"보수적", sell:"보수적(짧게)", order:21},
-      {name:"MFI-BOUNCE", info:"MFI 과매도→상승 반전", on:true, buy:"보수적", sell:"보수적(짧게)", order:22},
+      {name:"M-BREAK", info:"고변동·거래량 급증 시 20봉 최고가 돌파", on:true, order:1, rc:0, rw:"0%", rr:"0%", pc:0, pw:"0%", pr:"0%", data:"기본값"},
+      {name:"P-PULL", info:"상승 추세 중 단기 조정 진입", on:true, order:2, rc:0, rw:"0%", rr:"0%", pc:0, pw:"0%", pr:"0%", data:"기본값"},
+      {name:"T-FLOW", info:"강한 상승 추세 지속 종목 매수", on:true, order:3, rc:0, rw:"0%", rr:"0%", pc:0, pw:"0%", pr:"0%", data:"기본값"},
+      {name:"G-REV", info:"장기 하락 후 저점 부근 반전 매수", on:true, order:4, rc:0, rw:"0%", rr:"0%", pc:0, pw:"0%", pr:"0%", data:"기본값"},
+      {name:"VOL-BRK", info:"거래량 급증, 신고가 부근 상승 포착", on:true, order:5, rc:0, rw:"0%", rr:"0%", pc:0, pw:"0%", pr:"0%", data:"기본값"},
+      {name:"EMA-STACK", info:"EMA 상승 정배열+단기 조정 매수", on:true, order:6, rc:0, rw:"0%", rr:"0%", pc:0, pw:"0%", pr:"0%", data:"기본값"},
+      {name:"VWAP-BNC", info:"VWAP 지지 반등", on:true, order:7, rc:0, rw:"0%", rr:"0%", pc:0, pw:"0%", pr:"0%", data:"기본값"},
+      {name:"B-BAND", info:"볼린저 하단 이탈→재진입 반등", on:true, order:8, rc:0, rw:"0%", rr:"0%", pc:0, pw:"0%", pr:"0%", data:"기본값"},
+      {name:"BB-SQZ", info:"밴드 폭 축소+거래급증 돌파", on:true, order:9, rc:0, rw:"0%", rr:"0%", pc:0, pw:"0%", pr:"0%", data:"기본값"},
+      {name:"T-PULL", info:"추세 중 눌림목 반등 매수", on:true, order:10, rc:0, rw:"0%", rr:"0%", pc:0, pw:"0%", pr:"0%", data:"기본값"},
+      {name:"RSI-BOUNCE", info:"RSI 과매도→반등 매수", on:true, order:11, rc:0, rw:"0%", rr:"0%", pc:0, pw:"0%", pr:"0%", data:"기본값"},
+      {name:"BOLL-B", info:"볼린저 밴드 상단 돌파 매수", on:true, order:12, rc:0, rw:"0%", rr:"0%", pc:0, pw:"0%", pr:"0%", data:"기본값"},
+      {name:"BB-SQZ", info:"밴드 폭 축소+거래급증 돌파", on:true, order:13, rc:0, rw:"0%", rr:"0%", pc:0, pw:"0%", pr:"0%", data:"기본값"},
+      {name:"G-CROSS", info:"EMA 골든크로스+저항 돌파", on:true, order:14, rc:0, rw:"0%", rr:"0%", pc:0, pw:"0%", pr:"0%", data:"기본값"},
+      {name:"ATR-EXPLODE", info:"ATR 급등+추세전환", on:true, order:15, rc:0, rw:"0%", rr:"0%", pc:0, pw:"0%", pr:"0%", data:"기본값"},
+      {name:"MACD-MOM", info:"MACD GC+히스토그램 상승", on:true, order:16, rc:0, rw:"0%", rr:"0%", pc:0, pw:"0%", pr:"0%", data:"기본값"},
+      {name:"STOCH-BOUNCE", info:"Stoch 과매도+GC 반등", on:true, order:17, rc:0, rw:"0%", rr:"0%", pc:0, pw:"0%", pr:"0%", data:"기본값"},
+      {name:"RSI-DIV", info:"RSI 다이버전스+양봉", on:true, order:18, rc:0, rw:"0%", rr:"0%", pc:0, pw:"0%", pr:"0%", data:"기본값"},
+      {name:"I-BREAK", info:"일목균형 구름 돌파", on:true, order:19, rc:0, rw:"0%", rr:"0%", pc:0, pw:"0%", pr:"0%", data:"기본값"},
+      {name:"ADX-TRND", info:"ADX/DMI 상승 추세 진입", on:true, order:20, rc:0, rw:"0%", rr:"0%", pc:0, pw:"0%", pr:"0%", data:"기본값"},
+      {name:"SAR-REV", info:"PSAR 반전 신호 매수", on:true, order:21, rc:0, rw:"0%", rr:"0%", pc:0, pw:"0%", pr:"0%", data:"기본값"},
+      {name:"MFI-BOUNCE", info:"MFI 과매도→상승 반전", on:true, order:22, rc:0, rw:"0%", rr:"0%", pc:0, pw:"0%", pr:"0%", data:"기본값"},
     ];
 
-    function renderTable() {
+    function renderTable(){
       let html = "";
-      strategies.forEach((s, i) => {
+      strategies.forEach((s,i)=>{
         html += `<tr>
           <td>
             <label class="onoff-switch">
-              <input type="checkbox" ${s.on ? "checked" : ""} onchange="toggleOne(${i},this.checked)">
+              <input type="checkbox" ${s.on?"checked":""} onchange="toggleOne(${i},this.checked)">
               <span class="onoff-slider"></span>
             </label>
           </td>
           <td style="font-weight:900; color:var(--green); letter-spacing:-0.5px;">${s.name}</td>
-          <td>
-            <select class="dropdown" onchange="setBuy(${i},this.value)">
-              ${buyLevels.map(l=>`<option ${l===s.buy?"selected":""}>${l}</option>`).join("")}
-            </select>
-          </td>
-          <td>
-            <select class="dropdown" onchange="setSell(${i},this.value)">
-              ${sellLevels.map(l=>`<option ${l===s.sell?"selected":""}>${l}</option>`).join("")}
-            </select>
-          </td>
-          <td>
-            <input class="order-inp" type="number" min="1" max="22"
-                   value="${s.order}" onchange="setOrder(${i},this.value)">
-          </td>
-          <td style="position:relative;">
+          <td><input class="order-inp" type="number" min="1" max="22" value="${s.order}" onchange="setOrder(${i},this.value)"></td>
+          <td>${s.rc}</td><td>${s.rw}</td><td>${s.rr}</td>
+          <td>${s.pc}</td><td>${s.pw}</td><td>${s.pr}</td>
+          <td style="position:relative;">${s.data}
             <button class="info-btn" onmouseover="showTip(event,${i})" onmouseout="hideTip(event)">i</button>
             <div class="tooltip">${s.info}</div>
           </td>
         </tr>`;
       });
-      document.getElementById("tbl-body").innerHTML = html;
+      document.getElementById('tbl-body').innerHTML = html;
     }
-    // 일괄 전체 ON/OFF
-    function toggleAll(val){
-      strategies.forEach(s=>s.on=val);
-      renderTable();
-    }
-    function toggleOne(idx, val){
-      strategies[idx].on = val;
-    }
-    // 전체 적용 (상단 드롭다운 값 전체에)
-    function applyAllSettings(){
-      const allBuy = document.getElementById("all-buy").value;
-      const allSell = document.getElementById("all-sell").value;
-      strategies.forEach(s=>{ s.buy = allBuy; s.sell = allSell; });
-      renderTable();
-    }
-    function setBuy(idx, val){ strategies[idx].buy = val; renderTable(); }
-    function setSell(idx, val){ strategies[idx].sell = val; renderTable(); }
-    function setOrder(idx, val){ strategies[idx].order = Number(val); }
-    function resetDefaults(){
-      strategies.forEach((s,i)=>{s.on=true; s.buy="보수적"; s.sell="보수적(짧게)"; s.order=i+1;});
-      renderTable();
-    }
+
+    function toggleAll(v){ strategies.forEach(s=>s.on=v); renderTable(); }
+    function toggleOne(i,v){ strategies[i].on = v; }
+    function setOrder(i,v){ strategies[i].order = Number(v); }
+    function resetDefaults(){ strategies.forEach((s,i)=>{s.on=true; s.order=i+1; s.data='기본값';}); renderTable(); }
+    function restoreYesterday(){ alert('어제값 복원 예시'); }
+    function openWinrateModal(){ document.getElementById('win-modal-bg').style.display=''; document.getElementById('win-modal').style.display=''; }
+    function closeWinrateModal(){ document.getElementById('win-modal-bg').style.display='none'; document.getElementById('win-modal').style.display='none'; }
     function showTip(e,idx){
       let tip = e.target.nextElementSibling;
       tip.style.display='block';


### PR DESCRIPTION
## Summary
- remove buy/sell options from strategy settings
- show actual/expected results columns
- add winrate modal template and controls

## Testing
- `pytest -q`
