### PR TITLE
Fix monitor modal closing behavior

### DIFF
--- a/templates/00_base.html
+++ b/templates/00_base.html
@@ -127,7 +127,10 @@
           closeMonitorModal();
           location.reload();
         })
-        .catch(console.error);
+        .catch(err => {
+          console.error(err);
+          closeMonitorModal();
+        });
     }
     document.addEventListener('keydown', function(e) {
       if (e.key === "Escape") closeMonitorModal();


### PR DESCRIPTION
## Summary
- close the monitoring condition popup on save failures as well as success

## Testing
- `pytest -q`