### PR TITLE
Improve monitoring coin card layout

### DIFF
--- a/templates/01_Home.html
+++ b/templates/01_Home.html
@@ -34,12 +34,21 @@
           </svg>
         </button>
       </div>
-      <div class="flex flex-wrap gap-2 mt-2 mb-1">
-        {% for ticker in universe %}
-        <span class="inline-block w-8 h-8 rounded-full bg-green-400 text-xs flex items-center justify-center font-bold">
-          {{ ticker.replace('KRW-', '') }}
-        </span>
-        {% endfor %}
+      <div class="relative mt-2 mb-1 overflow-x-auto">
+        <div class="grid grid-rows-2 grid-flow-col gap-2 pr-4">
+          {% for ticker in universe %}
+          <span class="inline-flex items-center justify-center px-3 py-1 rounded-lg bg-green-400 text-xs font-bold text-gray-900 min-w-[48px]">
+            {{ ticker.replace('KRW-', '') }}
+          </span>
+          {% endfor %}
+        </div>
+        {% if universe|length > 8 %}
+        <div class="pointer-events-none absolute inset-y-0 right-0 w-5 flex items-center justify-center bg-gradient-to-l from-gray-800">
+          <svg class="w-3 h-3 text-gray-400" fill="currentColor" viewBox="0 0 20 20">
+            <path fill-rule="evenodd" d="M7 4l5 6-5 6V4z" clip-rule="evenodd" />
+          </svg>
+        </div>
+        {% endif %}
       </div>
     </div>
     <!-- 자동매매 카드 -->


### PR DESCRIPTION
## Summary
- display monitoring coins in a rounded rectangle style
- show 4 coins per row and handle overflow with a horizontal scroll indicator

## Testing
- `pytest -q`