### PR TITLE
Optimize orderbook requests

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,6 +8,10 @@ The latest selected trading universe is saved to `config/current_universe.json`.
 
 External processes such as `signal_loop.py` can use this file to share the same universe.
 
+## Orderbook batching
+
+`f1_universe.universe_selector.apply_filters` fetches orderbook data in batches of up to 100 tickers with a single API call per chunk. This reduces the number of requests sent to Upbit when building the universe.
+
 ## Running `signal_loop.py`
 
 To start the F1/F2 signal loop, run:

--- a/tests/test_universe.py
+++ b/tests/test_universe.py
@@ -1,0 +1,55 @@
+import sys
+import types
+import os
+
+sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), "..")))
+
+if 'requests' not in sys.modules:
+    fake_requests = types.SimpleNamespace()
+    sys.modules['requests'] = fake_requests
+
+from f1_universe import universe_selector as us
+
+
+def _make_fake_data(markets):
+    ticker_items = []
+    orderbook_items = []
+    for m in markets:
+        ticker_items.append({
+            "market": m,
+            "trade_price": 100.0,
+            "high_price": 110.0,
+            "low_price": 90.0,
+            "prev_closing_price": 100.0,
+        })
+        orderbook_items.append({
+            "market": m,
+            "orderbook_units": [{"ask_price": 101.0, "bid_price": 99.0}],
+        })
+    return ticker_items, orderbook_items
+
+
+def test_apply_filters_batches_requests(monkeypatch):
+    calls = []
+
+    def fake_fetch_json(url, params=None):
+        calls.append(url)
+        markets = params.get("markets", "").split(",")
+        if url.endswith("/ticker"):
+            data, _ = _make_fake_data(markets)
+            return data
+        elif url.endswith("/orderbook"):
+            _, data = _make_fake_data(markets)
+            return data
+        return []
+
+    monkeypatch.setattr(us, "_fetch_json", fake_fetch_json)
+
+    tickers = [f"KRW-{i:03d}" for i in range(150)]
+    cfg = {"max_spread": 1000.0}
+    result = us.apply_filters(tickers, cfg)
+
+    # Two calls per 100-ticker chunk: one for ticker and one for orderbook
+    assert len(calls) == 4
+    assert all(calls[i].endswith(path) for i, path in enumerate(["/ticker", "/orderbook", "/ticker", "/orderbook"]))
+    assert len(result) == len(tickers)


### PR DESCRIPTION
## Summary
- batch orderbook API requests when filtering tickers
- document batching behavior in the README
- add regression test ensuring batched requests

## Testing
- `pytest -q`