### PR TITLE
Filter replay trades by strategy

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,2 @@
+__pycache__/
+logs/

--- a/f3_order/replay.py
+++ b/f3_order/replay.py
@@ -7,8 +7,8 @@ def replay_trades(start_date: str, end_date: str, strategy_id: str, db_path: str
     conn = sqlite3.connect(db_path)
     cur = conn.cursor()
     cur.execute(
-        "SELECT * FROM orders WHERE timestamp BETWEEN ? AND ?",
-        (start_date, end_date),
+        "SELECT * FROM orders WHERE timestamp BETWEEN ? AND ? AND strategy_id = ?",
+        (start_date, end_date, strategy_id),
     )
     for row in cur.fetchall():
         yield row

--- a/tests/test_replay.py
+++ b/tests/test_replay.py
@@ -1,0 +1,26 @@
+import os
+import sqlite3
+
+from f3_order.replay import replay_trades
+
+
+def test_replay_trades_filters_by_strategy(tmp_path):
+    db = os.path.join(tmp_path, "orders.db")
+    conn = sqlite3.connect(db)
+    cur = conn.cursor()
+    cur.execute(
+        "CREATE TABLE orders (timestamp TEXT, uuid TEXT, symbol TEXT, side TEXT, qty REAL, price REAL, order_type TEXT, state TEXT, exit_type TEXT, slippage REAL, strategy_id TEXT)"
+    )
+    cur.executemany(
+        "INSERT INTO orders VALUES (?,?,?,?,?,?,?,?,?,?,?)",
+        [
+            ("2021-01-01T00:00:00", "u1", "KRW-BTC", "buy", 1.0, 100.0, "limit", "done", "", 0.0, "str1"),
+            ("2021-01-01T00:10:00", "u2", "KRW-BTC", "buy", 1.0, 101.0, "limit", "done", "", 0.0, "str2"),
+        ],
+    )
+    conn.commit()
+    conn.close()
+
+    trades = list(replay_trades("2021-01-01T00:00:00", "2021-01-01T00:20:00", "str1", db))
+    assert len(trades) == 1
+    assert trades[0][-1] == "str1"


### PR DESCRIPTION
## Summary
- filter `replay_trades` results using provided `strategy_id`
- add regression test
- ignore logs and caches

## Testing
- `pytest -q`