### PR TITLE
Update autotrade default state

### DIFF
--- a/templates/00_base.html
+++ b/templates/00_base.html
@@ -74,20 +74,14 @@
   <script>
     function toggleStatus(checkbox) {
       var status = document.getElementById("run-status");
-      var playIcon = document.getElementById("toggle-play");
-      var stopIcon = document.getElementById("toggle-stop");
       if (checkbox.checked) {
         status.textContent = "실행중";
         status.className =
           "w-full px-3 py-1 rounded-full text-sm font-bold bg-green-700 text-green-200 text-center mb-1";
-        playIcon.style.display = "";
-        stopIcon.style.display = "none";
       } else {
-        status.textContent = "정지됨";
+        status.textContent = "중단 상태";
         status.className =
           "w-full px-3 py-1 rounded-full text-sm font-bold bg-gray-700 text-gray-300 text-center mb-1";
-        playIcon.style.display = "none";
-        stopIcon.style.display = "";
       }
     }
     function openMonitorModal() {

--- a/templates/01_Home.html
+++ b/templates/01_Home.html
@@ -56,17 +56,15 @@
       <div class="flex items-center justify-between mb-3">
         <span class="card-title text-white">자동매매</span>
         <label class="toggle-switch ml-2" title="자동매매 실행/중지">
-          <input id="autotrade-toggle" type="checkbox" checked onchange="toggleStatus(this)">
+          <input id="autotrade-toggle" type="checkbox" onchange="toggleStatus(this)">
           <span class="toggle-slider">
-            <span class="icon" id="toggle-play">&#9654;</span>
-            <span class="icon" id="toggle-stop" style="display:none;">&#9632;</span>
             <span class="toggle-dot"></span>
           </span>
         </label>
       </div>
         <span id="run-status"
-              class="w-full px-3 py-1 rounded-full text-sm font-bold bg-green-700 text-green-200 text-center mb-1">
-          실행중
+              class="w-full px-3 py-1 rounded-full text-sm font-bold bg-gray-700 text-gray-300 text-center mb-1">
+          중단 상태
         </span>
       <div class="text-xs text-gray-400 text-right w-full mt-1">업데이트: 2024-05-25 14:11:21</div>
     </div>


### PR DESCRIPTION
## Summary
- default autotrading toggle to OFF when the site loads
- remove play/stop icons from the autotrade toggle
- keep label showing **중단 상태** when autotrade is off

## Testing
- `pytest -q`