### PR TITLE
Handle timezone localization properly

### DIFF
--- a/signal_loop.py
+++ b/signal_loop.py
@@ -17,6 +17,20 @@ from f1_universe.universe_selector import (
 from f2_signal.signal_engine import f2_signal
 
 
+def to_kst(timestamp_col):
+    """Ensure a pandas Timestamp or Series is in Asia/Seoul timezone."""
+    import pandas as pd
+
+    ts = pd.to_datetime(timestamp_col)
+    if hasattr(ts, "dt"):
+        if ts.dt.tz is None:
+            return ts.dt.tz_localize("Asia/Seoul")
+        return ts.dt.tz_convert("Asia/Seoul")
+    if ts.tzinfo is None:
+        return ts.tz_localize("Asia/Seoul")
+    return ts.tz_convert("Asia/Seoul")
+
+
 def fetch_ohlcv(symbol: str, interval: str, count: int = 50):
     """Fetch OHLCV data for *symbol* using pyupbit.
 
@@ -27,6 +41,13 @@ def fetch_ohlcv(symbol: str, interval: str, count: int = 50):
     try:
         df = pyupbit.get_ohlcv(symbol, interval=interval, count=count)
         df = df.reset_index().rename(columns={"index": "timestamp"})
+        try:
+            import pandas as pd  # noqa: F401
+
+            if hasattr(df, "columns") and "timestamp" in df.columns:
+                df["timestamp"] = to_kst(df["timestamp"])
+        except Exception:
+            pass
         return df
     except Exception as exc:  # pragma: no cover - network access
         logging.error(f"[{symbol}] Failed to fetch {interval} data: {exc}")


### PR DESCRIPTION
## Summary
- add `to_kst` helper handling naive vs. tz-aware timestamps
- use `to_kst` in `fetch_ohlcv` with fallback if pandas isn't installed

## Testing
- `pytest -q`