### PR TITLE
Implement log rotation

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,6 +21,8 @@ python signal_loop.py
 ```
 
 Logs are written to `logs/F1F2_loop.log`.
+Each log file automatically rotates when it exceeds 100&nbsp;MB. Previous files
+are numbered sequentially as `*.1`, `*.2`, and so on.
 
 
 ## Credentials

--- a/app.py
+++ b/app.py
@@ -6,6 +6,8 @@ import uuid
 import jwt
 import requests
 import datetime
+import logging
+from logging.handlers import RotatingFileHandler
 from signal_loop import process_symbol, main_loop
 from f1_universe.universe_selector import (
     select_universe,
@@ -61,12 +63,17 @@ def get_config_path(name: str) -> str:
 
 WEB_LOGGER = None
 if WEB_LOGGER is None:
-    import logging
-
     WEB_LOGGER = logging.getLogger("web")
     os.makedirs("logs", exist_ok=True)
-    handler = logging.FileHandler("logs/web.log", encoding="utf-8")
-    handler.setFormatter(logging.Formatter("%(asctime)s [WEB] %(levelname)s %(message)s"))
+    handler = RotatingFileHandler(
+        "logs/web.log",
+        encoding="utf-8",
+        maxBytes=100_000 * 1024,
+        backupCount=1000,
+    )
+    handler.setFormatter(
+        logging.Formatter("%(asctime)s [WEB] %(levelname)s %(message)s")
+    )
     WEB_LOGGER.addHandler(handler)
     WEB_LOGGER.setLevel(logging.INFO)
 
@@ -247,14 +254,18 @@ def settings():
 if __name__ == "__main__":
     # When running this file directly, also launch the signal processing loop
     # in a background thread so signals continue to be evaluated.
-    import logging
     import threading
 
     logging.basicConfig(
         level=logging.INFO,
         format="%(asctime)s [F1F2] [%(levelname)s] %(message)s",
         handlers=[
-            logging.FileHandler("logs/F1F2_loop.log", encoding="utf-8"),
+            RotatingFileHandler(
+                "logs/F1F2_loop.log",
+                encoding="utf-8",
+                maxBytes=100_000 * 1024,
+                backupCount=1000,
+            ),
             logging.StreamHandler(),
         ],
         force=True,

--- a/f1_universe/universe_selector.py
+++ b/f1_universe/universe_selector.py
@@ -16,6 +16,7 @@ import time
 from typing import Dict, List
 
 import logging
+from logging.handlers import RotatingFileHandler
 import requests
 
 os.makedirs("logs", exist_ok=True)
@@ -24,7 +25,12 @@ logging.basicConfig(
     level=logging.INFO,
     format="%(asctime)s [F1] [%(levelname)s] %(message)s",
     handlers=[
-        logging.FileHandler("logs/F1_signal_engine.log", encoding="utf-8"),
+        RotatingFileHandler(
+            "logs/F1_signal_engine.log",
+            encoding="utf-8",
+            maxBytes=100_000 * 1024,
+            backupCount=1000,
+        ),
         logging.StreamHandler(),
     ],
 )

--- a/f2_signal/signal_engine.py
+++ b/f2_signal/signal_engine.py
@@ -1,6 +1,7 @@
 import pandas as pd
 import json
 import logging
+from logging.handlers import RotatingFileHandler
 import numpy as np
 import os
 import re
@@ -25,7 +26,12 @@ logging.basicConfig(
     format="%(asctime)s [F2] [%(levelname)s] %(message)s",
     handlers=[
         logging.StreamHandler(),
-        logging.FileHandler(os.path.join("log", "F2_signal_engine.log"), encoding="utf-8"),
+        RotatingFileHandler(
+            os.path.join("log", "F2_signal_engine.log"),
+            encoding="utf-8",
+            maxBytes=100_000 * 1024,
+            backupCount=1000,
+        ),
     ],
 )
 

--- a/f3_order/exception_handler.py
+++ b/f3_order/exception_handler.py
@@ -3,6 +3,7 @@
 로그: logs/F3_exception_handler.log
 """
 import logging
+from logging.handlers import RotatingFileHandler
 try:
     import requests
 except Exception:  # pragma: no cover - offline test env
@@ -12,7 +13,12 @@ from urllib.parse import urlencode
 from .utils import log_with_tag, load_env
 
 logger = logging.getLogger("F3_exception_handler")
-fh = logging.FileHandler("logs/F3_exception_handler.log")
+fh = RotatingFileHandler(
+    "logs/F3_exception_handler.log",
+    encoding="utf-8",
+    maxBytes=100_000 * 1024,
+    backupCount=1000,
+)
 formatter = logging.Formatter('%(asctime)s [F3] %(message)s')
 fh.setFormatter(formatter)
 logger.addHandler(fh)

--- a/f3_order/kpi_guard.py
+++ b/f3_order/kpi_guard.py
@@ -3,11 +3,17 @@
 로그: logs/F3_kpi_guard.log
 """
 import logging
+from logging.handlers import RotatingFileHandler
 from .utils import log_with_tag
 from .exception_handler import ExceptionHandler
 
 logger = logging.getLogger("F3_kpi_guard")
-fh = logging.FileHandler("logs/F3_kpi_guard.log")
+fh = RotatingFileHandler(
+    "logs/F3_kpi_guard.log",
+    encoding="utf-8",
+    maxBytes=100_000 * 1024,
+    backupCount=1000,
+)
 formatter = logging.Formatter('%(asctime)s [F3] %(message)s')
 fh.setFormatter(formatter)
 logger.addHandler(fh)

--- a/f3_order/order_executor.py
+++ b/f3_order/order_executor.py
@@ -1,4 +1,5 @@
 import logging
+from logging.handlers import RotatingFileHandler
 from .smart_buy import smart_buy
 from .position_manager import PositionManager
 from .kpi_guard import KPIGuard
@@ -6,7 +7,12 @@ from .exception_handler import ExceptionHandler
 from .utils import load_config, now, log_with_tag
 
 logger = logging.getLogger("F3_order_executor")
-fh = logging.FileHandler("logs/F3_order_executor.log")
+fh = RotatingFileHandler(
+    "logs/F3_order_executor.log",
+    encoding="utf-8",
+    maxBytes=100_000 * 1024,
+    backupCount=1000,
+)
 formatter = logging.Formatter('%(asctime)s [F3] %(message)s')
 fh.setFormatter(formatter)
 logger.addHandler(fh)

--- a/f3_order/position_manager.py
+++ b/f3_order/position_manager.py
@@ -3,13 +3,19 @@
 로그: logs/F3_position_manager.log
 """
 import logging
+from logging.handlers import RotatingFileHandler
 import os
 import sqlite3
 from .utils import log_with_tag, now
 from .upbit_api import UpbitClient
 
 logger = logging.getLogger("F3_position_manager")
-fh = logging.FileHandler("logs/F3_position_manager.log")
+fh = RotatingFileHandler(
+    "logs/F3_position_manager.log",
+    encoding="utf-8",
+    maxBytes=100_000 * 1024,
+    backupCount=1000,
+)
 formatter = logging.Formatter('%(asctime)s [F3] %(message)s')
 fh.setFormatter(formatter)
 logger.addHandler(fh)

--- a/f3_order/smart_buy.py
+++ b/f3_order/smart_buy.py
@@ -3,10 +3,16 @@
 로그: logs/F3_smart_buy.log
 """
 import logging
+from logging.handlers import RotatingFileHandler
 from .utils import log_with_tag
 
 logger = logging.getLogger("F3_smart_buy")
-fh = logging.FileHandler("logs/F3_smart_buy.log")
+fh = RotatingFileHandler(
+    "logs/F3_smart_buy.log",
+    encoding="utf-8",
+    maxBytes=100_000 * 1024,
+    backupCount=1000,
+)
 formatter = logging.Formatter('%(asctime)s [F3] %(message)s')
 fh.setFormatter(formatter)
 logger.addHandler(fh)

--- a/f4_riskManager/risk_logger.py
+++ b/f4_riskManager/risk_logger.py
@@ -2,6 +2,7 @@
 F4 RiskLogger - 리스크/상태/이벤트 로그 및 알림
 """
 import logging
+from logging.handlers import RotatingFileHandler
 import os
 import sqlite3
 
@@ -9,7 +10,12 @@ class RiskLogger:
     def __init__(self, log_path, db_path="logs/risk_events.db"):
         self.logger = logging.getLogger("F4_risk_manager")
         os.makedirs(os.path.dirname(log_path), exist_ok=True)
-        fh = logging.FileHandler(log_path, encoding="utf-8")
+        fh = RotatingFileHandler(
+            log_path,
+            encoding="utf-8",
+            maxBytes=100_000 * 1024,
+            backupCount=1000,
+        )
         formatter = logging.Formatter('%(asctime)s [F4] %(levelname)s %(message)s')
         fh.setFormatter(formatter)
         self.logger.addHandler(fh)

--- a/signal_loop.py
+++ b/signal_loop.py
@@ -1,4 +1,5 @@
 import logging
+from logging.handlers import RotatingFileHandler
 import time
 from typing import Optional
 
@@ -114,7 +115,12 @@ if __name__ == "__main__":
         level=logging.INFO,
         format="%(asctime)s [F1F2] [%(levelname)s] %(message)s",
         handlers=[
-            logging.FileHandler("logs/F1F2_loop.log", encoding="utf-8"),
+            RotatingFileHandler(
+                "logs/F1F2_loop.log",
+                encoding="utf-8",
+                maxBytes=100_000 * 1024,
+                backupCount=1000,
+            ),
             logging.StreamHandler(),
         ],
         force=True,


### PR DESCRIPTION
## Summary
- rotate all log files when they exceed 100MB
- use `RotatingFileHandler` across modules
- mention log rotation in README

## Testing
- `pytest -q`