### PR TITLE
Fix logging paths and handlers

### DIFF
--- a/app.py
+++ b/app.py
@@ -266,6 +266,18 @@ if __name__ == "__main__":
                 maxBytes=100_000 * 1024,
                 backupCount=1000,
             ),
+            RotatingFileHandler(
+                "logs/F1_signal_engine.log",
+                encoding="utf-8",
+                maxBytes=100_000 * 1024,
+                backupCount=1000,
+            ),
+            RotatingFileHandler(
+                "logs/F2_signal_engine.log",
+                encoding="utf-8",
+                maxBytes=100_000 * 1024,
+                backupCount=1000,
+            ),
             logging.StreamHandler(),
         ],
         force=True,

--- a/f2_signal/signal_engine.py
+++ b/f2_signal/signal_engine.py
@@ -46,14 +46,14 @@ def _log_insufficient_data(symbol: str, strategy: str, required: int, available:
     }
     _log_jsonl("logs/insufficient_data.log", data)
 
-os.makedirs("log", exist_ok=True)
+os.makedirs("logs", exist_ok=True)
 logging.basicConfig(
     level=logging.DEBUG,
     format="%(asctime)s [F2] [%(levelname)s] %(message)s",
     handlers=[
         logging.StreamHandler(),
         RotatingFileHandler(
-            os.path.join("log", "F2_signal_engine.log"),
+            os.path.join("logs", "F2_signal_engine.log"),
             encoding="utf-8",
             maxBytes=100_000 * 1024,
             backupCount=1000,

--- a/signal_loop.py
+++ b/signal_loop.py
@@ -122,6 +122,18 @@ if __name__ == "__main__":
                 maxBytes=100_000 * 1024,
                 backupCount=1000,
             ),
+            RotatingFileHandler(
+                "logs/F1_signal_engine.log",
+                encoding="utf-8",
+                maxBytes=100_000 * 1024,
+                backupCount=1000,
+            ),
+            RotatingFileHandler(
+                "logs/F2_signal_engine.log",
+                encoding="utf-8",
+                maxBytes=100_000 * 1024,
+                backupCount=1000,
+            ),
             logging.StreamHandler(),
         ],
         force=True,


### PR DESCRIPTION
## Summary
- write F2 logs to the `logs` directory
- ensure main loop and web app include handlers for F1 and F2 log files

## Testing
- `pytest -q`