### PR TITLE
Implement balance sync on startup

### DIFF
--- a/README.md
+++ b/README.md
@@ -62,3 +62,11 @@ Risk events are recorded in `logs/risk_events.db` for later review.
 When the risk configuration file is modified (e.g. `config/setting_date/Latest_config.json`) the manager detects the change via `hot_reload()` and applies the new parameters immediately. A notification is also sent.
 
 To recover from a halted state simply restart the application or wait for `periodic()` to transition back to `ACTIVE` when allowed.
+
+## Initial balance sync
+
+When the application starts the `PositionManager` now fetches account balances
+using the Upbit API. Any holding worth at least 5,000 KRW is registered as an
+``imported`` position so that F2/F3 can monitor sell signals for it. Imported
+and ignored balances are logged to ``logs/position_init.log`` and a summary
+notification is sent via ``ExceptionHandler.send_alert``.

--- a/f3_order/upbit_api.py
+++ b/f3_order/upbit_api.py
@@ -100,3 +100,7 @@ class UpbitClient:
 
     def order_chance(self, market: str):
         return self.get("/v1/order_chance", {"market": market})
+
+    def get_accounts(self):
+        """Return account balances via ``/v1/accounts``."""
+        return self.get("/v1/accounts")

--- a/signal_loop.py
+++ b/signal_loop.py
@@ -96,6 +96,12 @@ def main_loop(interval: int = 1) -> None:
         universe = get_universe()
         if not universe:
             universe = select_universe(cfg)
+        imported = [
+            p.get("symbol")
+            for p in executor.position_manager.positions
+            if p.get("status") == "open" and p.get("origin") == "imported"
+        ]
+        universe = list(dict.fromkeys(universe + imported))
         logging.info(f"[Loop] Universe: {universe}")
         executor.position_manager.sync_with_universe(universe)
         # Update risk manager with open positions

--- a/tests/test_app_endpoints.py
+++ b/tests/test_app_endpoints.py
@@ -95,6 +95,9 @@ def app_client(monkeypatch):
                 "price": price,
             }
 
+        def get_accounts(self):
+            return []
+
     monkeypatch.setattr("f3_order.position_manager.UpbitClient", lambda: DummyClient())
 
     # Simplify smart_buy to include qty/price for position opening

--- a/tests/test_order_manager.py
+++ b/tests/test_order_manager.py
@@ -29,6 +29,9 @@ def make_pm(tmp_path, monkeypatch=None):
                     "volume": kwargs.get("volume"),
                 }
 
+            def get_accounts(self):
+                return []
+
         monkeypatch.setattr("f3_order.position_manager.UpbitClient", lambda: DummyClient())
     return PositionManager(cfg, dyn, guard, handler)
 
@@ -83,6 +86,9 @@ def test_place_order_partial_fill(tmp_path, monkeypatch):
                 "executed_volume": "1.0",
                 "price": kwargs.get("price"),
             }
+
+        def get_accounts(self):
+            return []
 
     monkeypatch.setattr("f3_order.position_manager.UpbitClient", lambda: PartialFillClient())
     pm = make_pm(tmp_path)

--- a/tests/test_position_import.py
+++ b/tests/test_position_import.py
@@ -1,0 +1,27 @@
+import os
+import sys
+sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), "..")))
+
+from f3_order.position_manager import PositionManager
+from f3_order.kpi_guard import KPIGuard
+from f3_order.exception_handler import ExceptionHandler
+
+class DummyClient:
+    def place_order(self, *args, **kwargs):
+        return {"uuid": "1", "state": "done", "side": kwargs.get("side"), "volume": kwargs.get("volume", 0)}
+
+    def get_accounts(self):
+        return [
+            {"currency": "XRP", "balance": "70", "avg_buy_price": "800", "unit_currency": "KRW"},
+            {"currency": "ETH", "balance": "0.001", "avg_buy_price": "3400000", "unit_currency": "KRW"},
+            {"currency": "KRW", "balance": "100000", "avg_buy_price": "1", "unit_currency": "KRW"},
+        ]
+
+
+def test_import_existing_positions(tmp_path, monkeypatch):
+    monkeypatch.setattr("f3_order.position_manager.UpbitClient", lambda: DummyClient())
+    cfg = {"DB_PATH": os.path.join(tmp_path, "orders.db")}
+    pm = PositionManager(cfg, {}, KPIGuard({}), ExceptionHandler({"SLIP_MAX": 0.15}))
+    assert len(pm.positions) == 1
+    assert pm.positions[0]["symbol"] == "KRW-XRP"
+    assert pm.positions[0]["origin"] == "imported"

--- a/tests/test_risk_manager.py
+++ b/tests/test_risk_manager.py
@@ -11,6 +11,9 @@ class DummyClient:
     def place_order(self, *args, **kwargs):
         return {"uuid": "1", "state": "done", "side": kwargs.get("side"), "volume": kwargs.get("volume", 0)}
 
+    def get_accounts(self):
+        return []
+
 
 def make_pm(tmp_path, monkeypatch):
     monkeypatch.setattr("f3_order.position_manager.UpbitClient", lambda: DummyClient())


### PR DESCRIPTION
## Summary
- load account balances through `UpbitClient.get_accounts`
- import holdings worth over 5k KRW in `PositionManager`
- keep imported coins independent of universe filtering and include them in the main loop
- notify via `ExceptionHandler` and log to `logs/position_init.log`
- update tests and add a new test for import logic
- document the feature in README

## Testing
- `pytest -q`