### PR TITLE
Ensure dashboard tables use REST APIs

### DIFF
--- a/README.md
+++ b/README.md
@@ -100,3 +100,31 @@ available via the API.
 
 - `GET` – return recent event log entries from `logs/events.jsonl`.
   The optional `limit` query parameter controls how many records are returned.
+
+## Dashboard data mapping
+
+`templates/01_Home.html` fetches runtime data for the dashboard from the
+new REST API endpoints. The "실시간 포지션 상세" table uses `/api/open_positions`
+and the "실시간 알림/이벤트" list uses `/api/events`. Both are refreshed every
+five seconds:
+
+```javascript
+function fetchPositions() {
+  fetch('/api/open_positions')
+    .then(r => r.json())
+    .then(renderPositions);
+}
+
+function fetchEvents() {
+  fetch('/api/events')
+    .then(r => r.json())
+    .then(renderEvents);
+}
+
+setInterval(fetchPositions, 5000);
+setInterval(fetchEvents, 5000);
+```
+
+Each position object contains the keys `symbol`, `strategy`, `entry_price`,
+`avg_price`, `current_price`, `eval_amount`, `pnl_percent`, `pyramid_count` and
+`avgdown_count`. Event objects contain `timestamp` and `message`.

--- a/templates/01_Home.html
+++ b/templates/01_Home.html
@@ -190,6 +190,69 @@ function fetchAutoTradeStatus() {
     .catch(console.error);
 }
 
+function fetchPositions() {
+  fetch('/api/open_positions')
+    .then(r => r.json())
+    .then(data => {
+      const body = document.getElementById('positions-body');
+      if (!body) return;
+      body.innerHTML = '';
+      if (data.length === 0) {
+        const row = document.createElement('tr');
+        row.className = 'text-center';
+        const cell = document.createElement('td');
+        cell.colSpan = 10;
+        cell.textContent = '포지션 없음';
+        row.appendChild(cell);
+        body.appendChild(row);
+        return;
+      }
+      data.forEach(pos => {
+        const row = document.createElement('tr');
+        row.className = 'border-b border-gray-700 text-center';
+        row.innerHTML = `
+          <td class="td-coin">${pos.symbol.replace('KRW-', '')}</td>
+          <td class="td-strategy">${pos.strategy ?? '-'}</td>
+          <td class="td-price">${Number(pos.entry_price ?? 0).toLocaleString()}</td>
+          <td class="td-price">${Number(pos.avg_price ?? 0).toLocaleString()}</td>
+          <td class="td-price">${Number(pos.current_price ?? 0).toLocaleString()}</td>
+          <td class="td-price">${Number(pos.eval_amount ?? 0).toLocaleString()}</td>
+          <td class="td-graph"></td>
+          <td class="td-pnl">${Number(pos.pnl_percent ?? 0).toFixed(2)}%</td>
+          <td class="td-burn">${pos.pyramid_count ?? 0}</td>
+          <td class="td-add">${pos.avgdown_count ?? 0}</td>`;
+        body.appendChild(row);
+      });
+    })
+    .catch(console.error);
+}
+
+function fetchEvents() {
+  fetch('/api/events')
+    .then(r => r.json())
+    .then(data => {
+      const list = document.getElementById('events-list');
+      if (!list) return;
+      list.innerHTML = '';
+      if (data.length === 0) {
+        const li = document.createElement('li');
+        li.textContent = '최근 이벤트 없음';
+        list.appendChild(li);
+        return;
+      }
+      data.forEach(ev => {
+        const li = document.createElement('li');
+        li.textContent = `${ev.timestamp} - ${ev.message}`;
+        list.appendChild(li);
+      });
+    })
+    .catch(console.error);
+}
+
 fetchAutoTradeStatus();
+fetchPositions();
+fetchEvents();
+setInterval(fetchPositions, 5000);
+setInterval(fetchEvents, 5000);
 </script>
 {% endblock %}


### PR DESCRIPTION
## Summary
- connect positions table and events list to `/api/open_positions` and `/api/events`
- document the dynamic mapping in the README

## Testing
- `pytest -q`