### PR TITLE
Ensure empty open positions return []

### DIFF
--- a/README.md
+++ b/README.md
@@ -89,7 +89,9 @@ available via the API.
 
 ### `/api/open_positions`
 
-- `GET` – list open positions managed by the order executor.
+- `GET` – list open positions managed by the order executor. The response is
+  always a JSON array. When no positions are open it returns an empty array
+  (`[]`).
   ```json
   [
     {"symbol": "KRW-BTC", "qty": 1, "status": "open"}

--- a/app.py
+++ b/app.py
@@ -311,7 +311,11 @@ def auto_trade_status_endpoint() -> Response:
 
 @app.route("/api/open_positions")
 def open_positions_endpoint() -> Response:
-    """Return currently open positions managed by the order executor."""
+    """Return a list of open positions from the order executor.
+
+    The endpoint always responds with a JSON array. When no positions are
+    being tracked the returned value is ``[]``.
+    """
     from f3_order.order_executor import _default_executor
 
     positions = [
@@ -319,7 +323,8 @@ def open_positions_endpoint() -> Response:
         for p in _default_executor.position_manager.positions
         if p.get("status") == "open"
     ]
-    return jsonify(positions)
+    # Explicitly return an empty array when no open positions exist.
+    return jsonify(positions if positions else [])
 
 
 @app.route("/api/events")

--- a/templates/01_Home.html
+++ b/templates/01_Home.html
@@ -198,6 +198,7 @@ function fetchPositions() {
       if (!body) return;
       body.innerHTML = '';
       if (data.length === 0) {
+        // Display a single row when there are no open positions
         const row = document.createElement('tr');
         row.className = 'text-center';
         const cell = document.createElement('td');

--- a/tests/test_app_endpoints.py
+++ b/tests/test_app_endpoints.py
@@ -192,6 +192,15 @@ def test_auto_trade_status_and_positions(app_client, tmp_path, monkeypatch):
     assert pos_resp.get_json()[0]["symbol"] == "KRW-BTC"
 
 
+def test_open_positions_empty(app_client):
+    client, order_executor, _ = app_client
+    # Ensure no positions are registered
+    order_executor._default_executor.position_manager.positions = []
+    resp = client.get("/api/open_positions")
+    assert resp.status_code == 200
+    assert resp.get_json() == []
+
+
 def test_events_endpoint(app_client, tmp_path, monkeypatch):
     client, _, _ = app_client
     import app as app_mod


### PR DESCRIPTION
## Summary
- clarify `/api/open_positions` behaviour in README
- explicitly return an empty array when no positions are open
- update frontend comment describing empty state
- add test confirming `/api/open_positions` returns `[]`

## Testing
- `pytest -q`