### PR TITLE
Fix market buy order conversion

### DIFF
--- a/f3_order/position_manager.py
+++ b/f3_order/position_manager.py
@@ -300,7 +300,7 @@ class PositionManager:
         trigger = self.dynamic_params.get("PYR_TRIGGER", 1.0)
         if (cur - position["entry_price"]) / position["entry_price"] * 100 >= trigger:
             qty = self.config.get("PYR_SIZE", 0) / cur
-            res = self.place_order(position["symbol"], "buy", qty)
+            res = self.place_order(position["symbol"], "buy", qty, "market", cur)
             if res.get("filled"):
                 position["qty"] += qty
                 position["pyramid_count"] += 1
@@ -316,7 +316,7 @@ class PositionManager:
         trigger = self.dynamic_params.get("AVG_TRIGGER", 1.0)
         if (position["entry_price"] - cur) / position["entry_price"] * 100 >= trigger:
             qty = self.config.get("AVG_SIZE", 0) / cur
-            res = self.place_order(position["symbol"], "buy", qty)
+            res = self.place_order(position["symbol"], "buy", qty, "market", cur)
             if res.get("filled"):
                 position["qty"] += qty
                 position["avgdown_count"] += 1

--- a/tests/test_upbit_api.py
+++ b/tests/test_upbit_api.py
@@ -1,0 +1,41 @@
+import os
+import sys
+
+sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), "..")))
+
+from f3_order.upbit_api import UpbitClient
+
+
+def test_market_buy_converts_to_price(monkeypatch):
+    captured = {}
+
+    def fake_post(self, path, params=None):
+        captured['path'] = path
+        captured['params'] = params
+        return {'uuid': '1', 'state': 'done'}
+
+    monkeypatch.setattr(UpbitClient, 'post', fake_post, raising=False)
+
+    client = UpbitClient('a', 'b')
+    client.place_order('KRW-XRP', 'bid', 1.0, 100.0, 'market')
+
+    assert captured['params']['ord_type'] == 'price'
+    assert captured['params']['price'] == '100.0'
+    assert 'volume' not in captured['params']
+
+
+def test_price_order_uses_amount(monkeypatch):
+    captured = {}
+
+    def fake_post(self, path, params=None):
+        captured['params'] = params
+        return {'uuid': '1', 'state': 'done'}
+
+    monkeypatch.setattr(UpbitClient, 'post', fake_post, raising=False)
+
+    client = UpbitClient('a', 'b')
+    client.place_order('KRW-XRP', 'bid', 2.0, 50.0, 'price')
+
+    assert captured['params']['ord_type'] == 'price'
+    assert captured['params']['price'] == '100.0'
+    assert 'volume' not in captured['params']


### PR DESCRIPTION
## Summary
- handle Upbit market buy orders as `price` type and compute amount
- pass current price to pyramiding and averaging-down orders
- add coverage for market buy parameter conversion

## Testing
- `pytest -q`