### PR TITLE
Add black-white theme and alert popups

### DIFF
--- a/app.py
+++ b/app.py
@@ -99,14 +99,20 @@ def load_strategy_master() -> list:
 
 
 def load_strategy_settings(path: str = STRATEGY_SETTINGS_FILE) -> list:
+    master = load_strategy_master()
+    defaults = {
+        s["short_code"]: {"short_code": s["short_code"], "on": True, "order": i + 1}
+        for i, s in enumerate(master)
+    }
     if path and os.path.exists(path):
         with open(path, "r", encoding="utf-8") as f:
-            return json.load(f)
-    master = load_strategy_master()
-    return [
-        {"short_code": s["short_code"], "on": True, "order": i + 1}
-        for i, s in enumerate(master)
-    ]
+            settings = json.load(f)
+        existing = {s.get("short_code") for s in settings}
+        for code, val in defaults.items():
+            if code not in existing:
+                settings.append(val)
+        return settings
+    return list(defaults.values())
 
 
 def save_strategy_settings(data: list, path: str = STRATEGY_SETTINGS_FILE) -> None:

--- a/templates/00_base.html
+++ b/templates/00_base.html
@@ -7,7 +7,16 @@
   <script src="https://cdn.tailwindcss.com"></script>
   <style>
     .card-title { font-weight: 700; font-size: 1.1rem; }
-    .main-bg { background: linear-gradient(135deg,#222831 65%,#1a232e 100%); }
+    .main-bg { background: linear-gradient(135deg,#0a0a0a 65%,#111 100%); }
+    .alert-bg {
+      position: fixed; inset: 0; background: rgba(0,0,0,0.6); display:none;
+      align-items: center; justify-content: center; z-index: 1000;
+    }
+    .alert-box {
+      background: #fff; color: #111; padding: 1.5rem 2rem; border-radius: 0.75rem;
+      font-weight: 700; min-width: 240px; text-align: center;
+      box-shadow: 0 8px 32px #000a;
+    }
     .toggle-switch { position: relative; width: 56px; height: 32px; display: inline-block; }
     .toggle-switch input { display: none; }
     .toggle-slider {
@@ -67,6 +76,9 @@
   <main class="max-w-7xl mx-auto px-4 py-8">
     {% block content %}{% endblock %}
   </main>
+  <div id="alertContainer" class="alert-bg">
+    <div id="alertBox" class="alert-box">알림</div>
+  </div>
   <footer class="text-center text-gray-500 text-sm py-8 mt-10 border-t border-green-900/30 bg-gray-950">
     &copy; 2025 <span class="text-green-400 font-semibold">AUTO UPBIT</span>. All rights reserved.
   </footer>
@@ -135,16 +147,28 @@
         .then(r => r.json())
         .then(() => {
           closeMonitorModal();
-          location.reload();
+          showAlert('저장되었습니다');
+          setTimeout(() => location.reload(), 800);
         })
         .catch(err => {
           console.error(err);
           closeMonitorModal();
+          showAlert('처리 중 오류 발생');
         });
     }
     document.addEventListener('keydown', function(e) {
       if (e.key === "Escape") closeMonitorModal();
     });
+
+    function showAlert(msg){
+      var bg = document.getElementById('alertContainer');
+      var box = document.getElementById('alertBox');
+      if(box) box.textContent = msg;
+      if(bg){
+        bg.style.display = 'flex';
+        setTimeout(() => { bg.style.display = 'none'; }, 1800);
+      }
+    }
   </script>
   {% block scripts %}{% endblock %}
 </body>

--- a/templates/01_Home.html
+++ b/templates/01_Home.html
@@ -5,16 +5,18 @@
   <div class="grid grid-cols-1 md:grid-cols-4 gap-5 mb-10">
     <div class="bg-gray-800 rounded-2xl shadow p-6 flex flex-col justify-center items-start h-36 min-w-[180px]">
       <div class="text-xs text-gray-400 mb-1">KRW 잔고</div>
-      <div id="krw-balance" class="text-3xl font-extrabold tracking-tight mt-1">0</div>
+      <div class="text-xs text-gray-500 mb-1">계좌 보유 현금</div>
+      <div id="krw-balance" class="text-3xl font-extrabold tracking-tight">0</div>
     </div>
     <div class="bg-gray-800 rounded-2xl shadow p-6 flex flex-col justify-center items-start h-36 min-w-[180px]">
       <div class="text-xs text-gray-400 mb-1">오늘 손익(PnL)</div>
-      <div class="flex items-baseline mt-1">
+      <div class="text-xs text-gray-500 mb-1">금일 실현 손익</div>
+      <div class="flex items-baseline">
         <span id="pnl-amount" class="text-3xl font-extrabold tracking-tight mr-2">0</span>
       </div>
     </div>
     <!-- 모니터링 코인 카드 -->
-    <div class="bg-gray-800 rounded-2xl shadow p-6 flex flex-col h-36 min-w-[240px] relative">
+    <div class="bg-gray-800 rounded-2xl shadow p-6 flex flex-col h-36 relative">
       <div class="flex items-center justify-between mb-2">
         <span class="card-title text-white">모니터링 코인</span>
         <button onclick="openMonitorModal()"
@@ -34,7 +36,8 @@
           </svg>
         </button>
       </div>
-      <div class="relative mt-2 mb-1 overflow-x-auto">
+      <div class="text-xs text-gray-500 mb-1">실시간 감시중인 종목</div>
+      <div class="relative mt-1 overflow-x-auto">
         <div class="grid grid-rows-2 grid-flow-col gap-2 pr-4">
           {% for ticker in universe %}
           <span class="inline-flex items-center justify-center px-3 py-1 rounded-lg bg-green-400 text-xs font-bold text-gray-900 min-w-[48px]">
@@ -66,13 +69,14 @@
               class="w-full px-3 py-1 rounded-full text-sm font-bold bg-gray-700 text-gray-300 text-center mb-1">
           중단 상태
         </span>
+      <div class="text-xs text-gray-500 mb-1">자동매매 실행 상태</div>
       <div id="autotrade-updated" class="text-xs text-gray-400 text-right w-full mt-1">업데이트: -</div>
     </div>
   </div>
 
-  <!-- 실시간 포지션 상세 (전략 표시, 수량 삭제) -->
+  <!-- 매도 모니터링 -->
   <div class="bg-gray-800 rounded-2xl shadow p-7 mb-8">
-    <h2 class="text-xl font-bold mb-4">실시간 포지션 상세</h2>
+    <h2 class="text-xl font-bold mb-4">매도 모니터링</h2>
     <div class="overflow-x-auto">
       <table class="w-full text-sm align-middle">
         <thead>
@@ -96,7 +100,7 @@
 
   <div class="bg-gray-800 rounded-2xl shadow p-7 mb-10">
     <h2 class="text-xl font-bold mb-4">실시간 알림/이벤트</h2>
-    <ul id="events-list"></ul>
+    <ul id="events-list" class="max-h-48 overflow-y-auto space-y-1"></ul>
   </div>
 
   <!-- 모니터링 코인 조건 팝업(모달) -->
@@ -237,7 +241,7 @@ function fetchPositions() {
 }
 
 function fetchEvents() {
-  fetch('/api/events')
+  fetch('/api/events?limit=20')
     .then(r => r.json())
     .then(data => {
       const list = document.getElementById('events-list');
@@ -249,9 +253,17 @@ function fetchEvents() {
         list.appendChild(li);
         return;
       }
-      data.forEach(ev => {
+      data.slice(-5).reverse().forEach(ev => {
         const li = document.createElement('li');
-        li.textContent = `${ev.timestamp} - ${ev.message}`;
+        li.className = 'flex justify-between border-b border-gray-700 text-sm py-1';
+        const time = document.createElement('span');
+        time.className = 'text-gray-400 w-24 pr-2';
+        time.textContent = ev.timestamp;
+        const msg = document.createElement('span');
+        msg.className = 'flex-1';
+        msg.textContent = ev.message;
+        li.appendChild(time);
+        li.appendChild(msg);
         list.appendChild(li);
       });
     })

--- a/templates/02_Strategy.html
+++ b/templates/02_Strategy.html
@@ -133,7 +133,8 @@
       left: 50%;
       top: 50%;
       transform: translate(-50%, -50%);
-      background: #1f2937;
+      background: #fff;
+      color: #111;
       border-radius: 17px;
       box-shadow: 0 8px 32px #000a;
       width: 600px;
@@ -142,12 +143,12 @@
     .modal-title {
       font-size: 1.2rem;
       font-weight: 700;
-      color: #fff;
+      color: #111;
       margin: 24px 0 12px 0;
       text-align: center;
     }
     .modal-table { width:100%; margin:20px 0; }
-    .modal-table th { background:#334155; font-weight:600; padding:8px; }
+    .modal-table th { background:#f3f3f3; color:#111; font-weight:600; padding:8px; }
     .modal-table td { padding:8px; text-align:center; }
     .modal-actions { text-align:center; margin-bottom:20px; }
     @media (max-width:1050px) { .main-wrap { max-width: 99vw; padding: 10px 2vw;}
@@ -261,7 +262,7 @@
       .then(d => {
         const ls = document.querySelector('.last-saved');
         if(ls) ls.textContent = '마지막 저장: ' + d.updated_at;
-        if(showMsg) alert('설정이 저장되었습니다!');
+        if(showMsg) showAlert('설정이 저장되었습니다');
       })
       .catch(console.error);
     }


### PR DESCRIPTION
## Summary
- auto-update strategy settings with new codes from master list
- style base template with dark gradient and custom alert popup
- add card descriptions and rename "실시간 포지션 상세" to "매도 모니터링"
- display events in a scrollable list and limit to five
- refine winrate modal and alert on save

## Testing
- `pytest -q`