### PR TITLE
Update log naming format

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,7 +20,7 @@ To start the F1/F2 signal loop, run:
 python signal_loop.py
 ```
 
-Logs are written to `logs/F1F2_loop.log`.
+Logs are written to `logs/F1-F2_loop.log`.
 Each log file automatically rotates when it exceeds 100&nbsp;MB. Previous files
 are numbered sequentially as `*.1`, `*.2`, and so on.
 

--- a/app.py
+++ b/app.py
@@ -484,10 +484,10 @@ start_monitoring()
 if __name__ == "__main__":
     logging.basicConfig(
         level=logging.INFO,
-        format="%(asctime)s [F1F2] [%(levelname)s] %(message)s",
+        format="%(asctime)s [F1-F2] [%(levelname)s] %(message)s",
         handlers=[
             RotatingFileHandler(
-                "logs/F1F2_loop.log",
+                "logs/F1-F2_loop.log",
                 encoding="utf-8",
                 maxBytes=100_000 * 1024,
                 backupCount=1000,

--- a/signal_loop.py
+++ b/signal_loop.py
@@ -122,10 +122,10 @@ def main_loop(interval: int = 1, stop_event=None) -> None:
 if __name__ == "__main__":
     logging.basicConfig(
         level=logging.INFO,
-        format="%(asctime)s [F1F2] [%(levelname)s] %(message)s",
+        format="%(asctime)s [F1-F2] [%(levelname)s] %(message)s",
         handlers=[
             RotatingFileHandler(
-                "logs/F1F2_loop.log",
+                "logs/F1-F2_loop.log",
                 encoding="utf-8",
                 maxBytes=100_000 * 1024,
                 backupCount=1000,


### PR DESCRIPTION
## Summary
- unify interface log tag `[F1F2]` to `[F1-F2]`
- rename `F1F2_loop.log` to `F1-F2_loop.log`
- update README

## Testing
- `pytest -q`