### PR TITLE
Enable live strategy settings reload

### DIFF
--- a/README.md
+++ b/README.md
@@ -107,7 +107,8 @@ available via the API.
 
 - `GET` – return the current strategy list with on/off states and priority.
 - `POST` – save an updated list. Each item should contain `short_code`, `on`
-  and `order` keys.
+  and `order` keys. Saved settings are reloaded immediately so changes take
+  effect without restarting the server.
 
 ## Dashboard data mapping
 

--- a/app.py
+++ b/app.py
@@ -20,6 +20,7 @@ from f1_universe.universe_selector import (
     load_universe_from_file,
     CONFIG_PATH,
 )
+from f2_signal.signal_engine import reload_strategy_settings
 
 app = Flask(__name__)
 
@@ -412,6 +413,7 @@ def strategies_endpoint() -> Response:
         except Exception:
             pass
     save_strategy_settings(settings, STRATEGY_SETTINGS_FILE)
+    reload_strategy_settings()
     ts = datetime.datetime.now().strftime("%Y-%m-%d %H:%M:%S")
     return jsonify({"status": "ok", "updated_at": ts})
 

--- a/f2_signal/signal_engine.py
+++ b/f2_signal/signal_engine.py
@@ -93,6 +93,22 @@ else:
 STRATEGY_SETTINGS = {s["short_code"]: s for s in _settings}
 
 
+def reload_strategy_settings() -> None:
+    """Reload per-strategy on/off and order settings from disk."""
+    global STRATEGY_SETTINGS
+    path = os.path.join("config", "strategy_settings.json")
+    if os.path.exists(path):
+        with open(path, "r", encoding="utf-8") as ssf:
+            settings = json.load(ssf)
+    else:
+        settings = [
+            {"short_code": s["short_code"], "on": True, "order": i + 1}
+            for i, s in enumerate(strategies)
+        ]
+    # Replace the mapping atomically for thread safety
+    STRATEGY_SETTINGS = {s["short_code"]: s for s in settings}
+
+
 def _as_utc(ts):
     """Return a timezone-aware timestamp in UTC."""
     ts = pd.to_datetime(ts)


### PR DESCRIPTION
## Summary
- allow reloading strategy settings from disk
- refresh strategy settings after POST to `/api/strategies`
- document that strategy updates apply immediately
- test reload logic with POST handler

## Testing
- `pytest -q`