### PR TITLE
UI: adjust header toggle and grid

### DIFF
--- a/templates/00_base.html
+++ b/templates/00_base.html
@@ -17,7 +17,7 @@
       font-weight: 700; min-width: 240px; text-align: center;
       box-shadow: 0 8px 32px #000a;
     }
-    .toggle-switch { position: relative; width: 56px; height: 32px; display: inline-block; }
+    .toggle-switch { position: relative; width: 70px; height: 32px; display: inline-block; }
     .toggle-switch input { display: none; }
     .toggle-slider {
       position: absolute; cursor: pointer; top: 0; left: 0; right: 0; bottom: 0;
@@ -34,7 +34,7 @@
       transition: left 0.22s;
     }
     .toggle-switch input:checked + .toggle-slider .toggle-dot {
-      left: 28px; background: #fff;
+      left: 42px; background: #fff;
     }
     th, td { white-space: nowrap; }
     .td-coin { min-width: 64px; }
@@ -64,13 +64,23 @@
         <span class="text-green-400 text-2xl font-black tracking-tight">AUTO<span class="text-white">UPBIT</span></span>
         <span class="ml-2 px-2 py-0.5 rounded-full text-xs bg-green-900/50 text-green-300 font-semibold">실시간</span>
       </div>
-      <nav class="flex gap-6 text-base font-semibold">
-        <a href="{{ url_for('dashboard') }}" class="hover:text-green-400 transition">대시보드</a>
-        <a href="{{ url_for('strategy') }}" class="hover:text-green-400 transition">전략 설정</a>
-        <a href="{{ url_for('risk') }}" class="hover:text-green-400 transition">리스크 셋팅</a>
-        <a href="{{ url_for('analysis') }}" class="hover:text-green-400 transition">데이터 분석</a>
-        <a href="{{ url_for('settings') }}" class="hover:text-green-400 transition">개인 설정</a>
-      </nav>
+      <div class="flex items-center gap-6">
+        <nav class="flex gap-6 text-base font-semibold">
+          <a href="{{ url_for('dashboard') }}" class="hover:text-green-400 transition">대시보드</a>
+          <a href="{{ url_for('strategy') }}" class="hover:text-green-400 transition">전략 설정</a>
+          <a href="{{ url_for('risk') }}" class="hover:text-green-400 transition">리스크 셋팅</a>
+          <a href="{{ url_for('analysis') }}" class="hover:text-green-400 transition">데이터 분석</a>
+          <a href="{{ url_for('settings') }}" class="hover:text-green-400 transition">개인 설정</a>
+        </nav>
+        <div class="flex items-center gap-1">
+          <span id="status-off" class="text-red-500 text-sm font-bold">중단</span>
+          <label class="toggle-switch" title="자동매매 실행/중지">
+            <input id="autotrade-toggle" type="checkbox" onchange="toggleStatus(this)">
+            <span class="toggle-slider"><span class="toggle-dot"></span></span>
+          </label>
+          <span id="status-on" class="text-gray-400 text-sm font-bold">실행중</span>
+        </div>
+      </div>
     </div>
   </header>
   <main class="max-w-7xl mx-auto px-4 py-8">
@@ -91,25 +101,49 @@
       })
         .then(r => r.json())
         .then(d => {
-          var status = document.getElementById('run-status');
-          var updated = document.getElementById('autotrade-updated');
-          if (status) {
+          var off = document.getElementById('status-off');
+          var on = document.getElementById('status-on');
+          if (off && on) {
             if (d.enabled) {
-              status.textContent = '실행중';
-              status.className =
-                'w-full px-3 py-1 rounded-full text-sm font-bold bg-green-700 text-green-200 text-center mb-1';
+              off.className = 'text-gray-400 text-sm font-bold';
+              on.className = 'text-green-400 text-sm font-bold';
             } else {
-              status.textContent = '중단 상태';
-              status.className =
-                'w-full px-3 py-1 rounded-full text-sm font-bold bg-gray-700 text-gray-300 text-center mb-1';
+              off.className = 'text-red-500 text-sm font-bold';
+              on.className = 'text-gray-400 text-sm font-bold';
             }
           }
-          if (updated) updated.textContent = '업데이트: ' + d.updated_at;
         })
         .catch(err => {
           console.error(err);
           checkbox.checked = !checkbox.checked;
           if (typeof fetchAutoTradeStatus === 'function') fetchAutoTradeStatus();
+        });
+    }
+    function fetchAutoTradeStatus() {
+      fetch('/api/auto_trade_status')
+        .then(r => r.json())
+        .then(d => {
+          var checkbox = document.getElementById('autotrade-toggle');
+          var off = document.getElementById('status-off');
+          var on = document.getElementById('status-on');
+          if (checkbox) checkbox.checked = d.enabled;
+          if (off && on) {
+            if (d.enabled) {
+              off.className = 'text-gray-400 text-sm font-bold';
+              on.className = 'text-green-400 text-sm font-bold';
+            } else {
+              off.className = 'text-red-500 text-sm font-bold';
+              on.className = 'text-gray-400 text-sm font-bold';
+            }
+          }
+        })
+        .catch(() => {
+          var off = document.getElementById('status-off');
+          var on = document.getElementById('status-on');
+          if (off && on) {
+            off.className = 'text-red-500 text-sm font-bold';
+            on.className = 'text-gray-400 text-sm font-bold';
+          }
         });
     }
     function openMonitorModal() {
@@ -169,6 +203,8 @@
         setTimeout(() => { bg.style.display = 'none'; }, 1800);
       }
     }
+    fetchAutoTradeStatus();
+    setInterval(fetchAutoTradeStatus, 5000);
   </script>
   {% block scripts %}{% endblock %}
 </body>

--- a/templates/01_Home.html
+++ b/templates/01_Home.html
@@ -1,14 +1,14 @@
 {% extends '00_base.html' %}
 {% block title %}AUTO UPBIT 실전 대시보드{% endblock %}
 {% block content %}
-  <!-- 4분할 상단 Row -->
-  <div class="grid grid-cols-1 md:grid-cols-4 gap-5 mb-10">
-    <div class="bg-gray-800 rounded-2xl shadow p-6 flex flex-col justify-center items-start h-36 min-w-[180px]">
+  <!-- 상단 카드 Row -->
+  <div class="grid grid-cols-1 md:grid-cols-5 gap-5 mb-10">
+    <div class="bg-gray-800 rounded-2xl shadow p-6 flex flex-col justify-center items-start h-36 min-w-[180px] col-span-1">
       <div class="card-title text-white mb-1">KRW 잔고</div>
       <div class="text-xs text-gray-500 mb-1">계좌 보유 현금</div>
       <div id="krw-balance" class="text-3xl font-extrabold tracking-tight">0</div>
     </div>
-    <div class="bg-gray-800 rounded-2xl shadow p-6 flex flex-col justify-center items-start h-36 min-w-[180px]">
+    <div class="bg-gray-800 rounded-2xl shadow p-6 flex flex-col justify-center items-start h-36 min-w-[180px] col-span-1">
       <div class="card-title text-white mb-1">오늘 손익(PnL)</div>
       <div class="text-xs text-gray-500 mb-1">금일 실현 손익</div>
       <div class="flex items-baseline">
@@ -16,7 +16,7 @@
       </div>
     </div>
     <!-- 모니터링 코인 카드 -->
-    <div class="bg-gray-800 rounded-2xl shadow p-6 flex flex-col h-36 relative">
+    <div class="bg-gray-800 rounded-2xl shadow p-6 flex flex-col h-36 relative col-span-3">
       <div class="flex items-center justify-between mb-2">
         <span class="card-title text-white">모니터링 코인</span>
         <button onclick="openMonitorModal()"
@@ -53,24 +53,6 @@
         </div>
         {% endif %}
       </div>
-    </div>
-    <!-- 자동매매 카드 -->
-    <div class="bg-gray-800 rounded-2xl shadow p-6 flex flex-col justify-between h-36 min-w-[200px] relative">
-      <div class="flex items-center justify-between mb-3">
-        <span class="card-title text-white">자동매매</span>
-        <label class="toggle-switch ml-2" title="자동매매 실행/중지">
-          <input id="autotrade-toggle" type="checkbox" onchange="toggleStatus(this)">
-          <span class="toggle-slider">
-            <span class="toggle-dot"></span>
-          </span>
-        </label>
-      </div>
-        <span id="run-status"
-              class="w-full px-3 py-1 rounded-full text-sm font-bold bg-gray-700 text-gray-300 text-center mb-1">
-          중단 상태
-        </span>
-      <div class="text-xs text-gray-500 mb-1">자동매매 실행 상태</div>
-      <div id="autotrade-updated" class="text-xs text-gray-400 text-right w-full mt-1">업데이트: -</div>
     </div>
   </div>
 
@@ -170,37 +152,6 @@ function updateAccount() {
 updateAccount();
 setInterval(updateAccount, 10000);
 
-function fetchAutoTradeStatus() {
-  fetch('/api/auto_trade_status')
-    .then(r => r.json())
-    .then(d => {
-      const checkbox = document.getElementById('autotrade-toggle');
-      const status = document.getElementById('run-status');
-      const updated = document.getElementById('autotrade-updated');
-      if (checkbox) checkbox.checked = d.enabled;
-      if (status) {
-        if (d.enabled) {
-          status.textContent = '실행중';
-          status.className =
-            'w-full px-3 py-1 rounded-full text-sm font-bold bg-green-700 text-green-200 text-center mb-1';
-        } else {
-          status.textContent = '중단 상태';
-          status.className =
-            'w-full px-3 py-1 rounded-full text-sm font-bold bg-gray-700 text-gray-300 text-center mb-1';
-        }
-      }
-      if (updated) updated.textContent = '업데이트: ' + d.updated_at;
-    })
-    .catch(err => {
-      console.error(err);
-      const status = document.getElementById('run-status');
-      if (status) {
-        status.textContent = '연결 오류';
-        status.className =
-          'w-full px-3 py-1 rounded-full text-sm font-bold bg-red-700 text-red-200 text-center mb-1';
-      }
-    });
-}
 
 function fetchPositions() {
   fetch('/api/open_positions')
@@ -284,10 +235,8 @@ function fetchEvents() {
     .catch(console.error);
 }
 
-fetchAutoTradeStatus();
 fetchPositions();
 fetchEvents();
-setInterval(fetchAutoTradeStatus, 5000);
 setInterval(fetchPositions, 5000);
 setInterval(fetchEvents, 5000);
 </script>


### PR DESCRIPTION
## Summary
- lengthen auto-trade toggle and remove update timestamp
- show enabled/disabled status on each side of the header toggle
- set dashboard card grid ratio to `1:1:3`

## Testing
- `pytest -q`