### PR TITLE
Fix RiskManager pause timing and add tqdm dependency

### DIFF
--- a/doc/f5_ml_pipeline.md
+++ b/doc/f5_ml_pipeline.md
@@ -10,4 +10,5 @@ Retrieves 1 minute OHLCV data for the last 90 days using the Upbit REST API. The
 - Downloads complete candle data via `/v1/candles/minutes/1` respecting rate limits.
 - Saves each market as a CSV file under `f5_ml_pipeline/ml_data/01_raw/`.
 
-Run the script directly to start collection.
+The script depends on the `tqdm` package for progress bars. Install requirements
+via `pip install -r requirements.txt` and run the script to start collection.

--- a/f4_riskManager/risk_utils.py
+++ b/f4_riskManager/risk_utils.py
@@ -10,6 +10,6 @@ class RiskState(Enum):
     DISABLE = 3
     HALT = 4
 
-def now():
-    """현재 epoch timestamp 반환(초)"""
-    return int(time.time())
+def now() -> float:
+    """Return current epoch timestamp in seconds as a float."""
+    return time.time()

--- a/f5_ml_pipeline/F5_README.md
+++ b/f5_ml_pipeline/F5_README.md
@@ -1,3 +1,6 @@
 # 폴더/프로세스 설명
 
 This folder contains a step-by-step ML pipeline for the trading system.
+Common helper functions used across the pipeline are provided in
+`F5_utils.py`. The module currently exposes a `now()` function that returns
+the current timestamp as a floating point number.

--- a/f5_ml_pipeline/F5_utils.py
+++ b/f5_ml_pipeline/F5_utils.py
@@ -1,2 +1,9 @@
 # 공통 함수/유틸
+import time
+
+
+def now() -> float:
+    """Return current epoch timestamp as a floating point number."""
+    return time.time()
+
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -14,3 +14,4 @@ requests==2.31.0
 PyJWT==2.8.0
 wheel
 ta-lib
+tqdm==4.66.4


### PR DESCRIPTION
## Summary
- avoid missing dependencies by including tqdm
- ensure RiskManager recovers from a zero-duration pause using float time
- document tqdm usage in the ML data fetch script
- provide F5 utilities module with `now()` helper

## Testing
- `pytest -q`
