### PR TITLE
Fix 04_label import path for script execution

### DIFF
--- a/doc/f5_ml_pipeline.md
+++ b/doc/f5_ml_pipeline.md
@@ -41,5 +41,6 @@ runtime so new strategies can be added without modifying the code. Feature
 files from `ml_data/03_features/` are labelled and written to
 `ml_data/04_labels/` using the same filenames. Placeholder columns such as
 `entry_price`, `exit_price` and `peak` are created when missing so backtests can
-reference them immediately. Run this step after generating features with:
-`python f5_ml_pipeline/04_label.py`.
+reference them immediately. You can run this step directly from the repository
+root using `python f5_ml_pipeline/04_label.py`. The script automatically adjusts
+`sys.path` so that `strategy_loader` is imported correctly.

--- a/f5_ml_pipeline/04_label.py
+++ b/f5_ml_pipeline/04_label.py
@@ -2,13 +2,17 @@
 
 from __future__ import annotations
 
+import sys
 from pathlib import Path
 
 import pandas as pd
 
-from .strategy_loader import load_strategies
-
 BASE_DIR = Path(__file__).resolve().parent
+# Allow running this script directly from the repository root by making
+# package imports resolvable.
+sys.path.insert(0, str(BASE_DIR.parent))
+
+from f5_ml_pipeline.strategy_loader import load_strategies
 RAW_DIR = BASE_DIR / "ml_data/03_features"
 LABEL_DIR = BASE_DIR / "ml_data/04_labels"
 LABEL_DIR.mkdir(parents=True, exist_ok=True)


### PR DESCRIPTION
## Summary
- ensure `f5_ml_pipeline/04_label.py` works when executed directly
- document the new behavior in the ML pipeline docs

## Testing
- `pytest -q`