### PR TITLE
Add dependencies for ML tuning step

### DIFF
--- a/doc/f5_ml_pipeline.md
+++ b/doc/f5_ml_pipeline.md
@@ -63,3 +63,6 @@ loaded for each symbol. The best parameters are saved to
 study. This step expects at least one column containing the word `label` which
 is treated as the target.
 Execute it from the repository root with `python f5_ml_pipeline/06_optuna_tpe.py`.
+This step depends on the `optuna`, `lightgbm` and `scikit-learn` packages
+which are now included in `requirements.txt`. Install them before running
+the optimisation script.

--- a/requirements.txt
+++ b/requirements.txt
@@ -16,3 +16,6 @@ wheel
 ta-lib
 tqdm==4.66.4
 pyarrow==15.0.2
+optuna==3.5.0
+lightgbm==4.3.0
+scikit-learn==1.4.2


### PR DESCRIPTION
## Summary
- document required packages for Optuna tuning step
- include optuna, lightgbm and scikit-learn in requirements

## Testing
- `pytest -q`