### PR TITLE
Fix sell monitoring table formatting and docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -156,3 +156,5 @@ setInterval(fetchEvents, 5000);
 Each position object contains the keys `symbol`, `strategy`, `entry_price`,
 `avg_price`, `current_price`, `eval_amount`, `pnl_percent`, `pyramid_count` and
 `avgdown_count`. Event objects contain `timestamp` and `message`.
+The `strategy` field records the name of the buy strategy used when the
+position was opened.

--- a/templates/00_base.html
+++ b/templates/00_base.html
@@ -38,9 +38,9 @@
     }
     th, td { white-space: nowrap; }
     .td-coin { min-width: 64px; }
-    .td-strategy { min-width: 110px; }
+    .td-strategy { min-width: 110px; text-align: center; }
     .td-price { min-width: 100px; text-align: right; }
-    .td-graph { min-width: 220px; }
+    .td-graph { min-width: 220px; padding: 0 10px; }
     .td-pnl { min-width: 75px; text-align: right; }
     .td-burn, .td-add { min-width: 48px; text-align: center; }
     ::-webkit-scrollbar { height:6px; width:6px; background:#2d3748; }

--- a/templates/01_Home.html
+++ b/templates/01_Home.html
@@ -184,9 +184,9 @@ function fetchPositions() {
         row.innerHTML = `
           <td class="td-coin">${pos.symbol.replace('KRW-', '')}</td>
           <td class="td-strategy">${pos.strategy ?? '-'}</td>
-          <td class="td-price">${Number(pos.avg_price ?? 0).toLocaleString()}</td>
-          <td class="td-price">${Number(pos.current_price ?? 0).toLocaleString()}</td>
-          <td class="td-price">${Number(pos.eval_amount ?? 0).toLocaleString()}</td>
+          <td class="td-price">${Math.floor(Number(pos.avg_price ?? 0)).toLocaleString()}</td>
+          <td class="td-price">${Math.floor(Number(pos.current_price ?? 0)).toLocaleString()}</td>
+          <td class="td-price">${Math.floor(Number(pos.eval_amount ?? 0)).toLocaleString()}</td>
           <td class="td-graph"></td>
           <td class="td-pnl">${Number(pos.pnl_percent ?? 0).toFixed(2)}%</td>
           <td class="td-burn">${pos.pyramid_count ?? 0}</td>
@@ -197,12 +197,13 @@ function fetchPositions() {
           const tp = Number(riskCfg.TP_PCT || 1);
           const total = sl + tp;
           const curPct = Number(pos.pnl_percent || 0);
+          const mid = (sl / total) * 100;
           let posX = ((curPct + sl) / total) * 100;
           posX = Math.max(0, Math.min(100, posX));
           g.innerHTML = `
             <div class="relative h-1.5 bg-gray-700 rounded">
               <div class="absolute inset-y-0 left-0 w-px bg-red-500"></div>
-              <div class="absolute inset-y-0 left-1/2 w-px bg-gray-300"></div>
+              <div class="absolute inset-y-0 w-px bg-gray-300" style="left:${mid}%"></div>
               <div class="absolute inset-y-0 right-0 w-px bg-green-500"></div>
               <div class="absolute inset-y-0 w-1 bg-blue-400" style="left:${posX}%"></div>
             </div>


### PR DESCRIPTION
## Summary
- adjust table cell styles for strategy column and profit graph
- round numeric values to whole numbers in dashboard
- align profit graph center to entry price
- document `strategy` field in README

## Testing
- `pytest -q`