### PR TITLE
Add strategy-based sell evaluation

### DIFF
--- a/doc/overview.md
+++ b/doc/overview.md
@@ -37,3 +37,9 @@ Whenever a new trade is opened the current list of holdings is written to
 `config/coin_positions.json`. Each entry contains the symbol, entry price,
 quantity and strategy information. This file can be inspected to see which
 coins are being monitored even after restarting the application.
+
+Each position stores the strategy code used on entry. The system now checks
+the corresponding `sell_formula` from `strategies_master_pruned.json` on every
+update. When that expression evaluates to `True` using the latest 1-minute
+candle along with the position's entry and peak prices the coin is automatically
+sold via the order executor.

--- a/tests/test_signal.py
+++ b/tests/test_signal.py
@@ -151,3 +151,23 @@ def test_f2_signal_accepts_tzaware():
     })
     result = f2_signal(df1, df5, symbol="TZAWARE")
     assert {"symbol", "buy_signal", "sell_signal"} <= result.keys()
+
+
+@pytest.mark.skipif(not pandas_available, reason="pandas not available")
+def test_eval_formula_with_entry_and_peak():
+    row = pd.Series({
+        "close": 110,
+        "open": 110,
+        "high": 110,
+        "low": 110,
+        "volume": 1,
+        "EMA_5": 100,
+        "EMA_20": 90,
+        "RSI_14": 70,
+    })
+    formula = (
+        "Close >= Entry * 1.015 or Close <= Peak * 0.992 or "
+        "Close <= Entry * 0.993 or RSI(14) < 60 or EMA(5) < EMA(20)"
+    )
+    res = eval_formula(formula, row, entry=100, peak=110)
+    assert res


### PR DESCRIPTION
## Summary
- extend `eval_formula` to accept `entry` and `peak`
- evaluate sell strategy on open positions in `signal_loop`
- update documentation on automatic selling
- add unit test for `eval_formula` with entry/peak

## Testing
- `pytest -q`