### PR TITLE
Implement buy-only monitoring for universe

### DIFF
--- a/doc/overview.md
+++ b/doc/overview.md
@@ -6,7 +6,9 @@ This repository implements a four stage trading system built around the Upbit ex
   filters such as volume and price. Results are stored in `config/current_universe.json`.
 - **F2 Signal Engine** – evaluates OHLCV data for each symbol and produces buy/sell
   signals. The `signal_loop.py` script orchestrates data collection and executes this
-  engine.
+  engine. Symbols from `current_universe.json` are treated as buy candidates only –
+  their sell conditions are ignored until a position is opened. Sell rules are
+  evaluated exclusively for coins listed in `coin_positions.json`.
 - **F3 Order Executor** – receives signals and places orders using the Upbit API.
   It maintains open positions, handles slippage and keeps a SQLite order log. When
   linked to the Risk Manager the executor mirrors updated sizing parameters like

--- a/signal_loop.py
+++ b/signal_loop.py
@@ -94,8 +94,14 @@ def process_symbol(symbol: str) -> Optional[dict]:
     if df_1m is None or df_5m is None or df_1m.empty or df_5m.empty:
         logging.warning(f"[{symbol}] No OHLCV data available")
         return None
-    logging.info(f"[F1-F2] process_symbol() \uc774 OHLCV \ub370\uc774\ud130\ub97c \uac00\uc838\uc654\uc2b5\ub2c8\ub2e4: {symbol}")
-    result = f2_signal(df_1m, df_5m, symbol)
+
+    logging.info(
+        f"[F1-F2] process_symbol() \uc774 OHLCV \ub370\uc774\ud130\ub97c \uac00\uc838\uc654\uc2b5\ub2c8\ub2e4: {symbol}"
+    )
+
+    pm = _default_executor.position_manager
+    has_pos = any(p.get("symbol") == symbol and p.get("status") == "open" for p in pm.positions)
+    result = f2_signal(df_1m, df_5m, symbol, calc_buy=not has_pos, calc_sell=False)
     logging.info(f"[F1-F2] process_symbol() \uac01 \uc2ec\ubd80\uc5d0 \ub300\ud55c f2_signal() \ud638\ucd9c\uc774 \uc644\ub8cc\ub418\uc5c8\uc2b5\ub2c8\ub2e4: {symbol}")
     if result.get("buy_signal") or result.get("sell_signal"):
         logging.info(

--- a/tests/test_app_endpoints.py
+++ b/tests/test_app_endpoints.py
@@ -10,7 +10,7 @@ sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), "..")
 def app_client(monkeypatch):
     # Stub f2_signal module to avoid pandas dependency
     stub = types.ModuleType("signal_engine")
-    def fake_f2_signal(df1, df5, symbol=""):
+    def fake_f2_signal(df1, df5, symbol="", **_kw):
         return {
             "symbol": symbol,
             "buy_signal": True,

--- a/tests/test_order_manager.py
+++ b/tests/test_order_manager.py
@@ -1,5 +1,6 @@
 import os
 import sqlite3
+import json
 import sys
 sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), "..")))
 from f3_order.position_manager import PositionManager
@@ -106,4 +107,14 @@ def test_place_order_partial_fill(tmp_path, monkeypatch):
     pm.place_order("KRW-BTC", "sell", 2.0, "market", 100.0)
     assert pm.positions[0]["qty"] == 1.0
     assert pm.positions[0]["status"] == "open"
+
+
+def test_open_position_stores_strategy(tmp_path, monkeypatch):
+    pm = make_pm(tmp_path, monkeypatch)
+    pm.positions_file = os.path.join(tmp_path, "pos.json")
+    order = {"symbol": "KRW-BTC", "price": 100.0, "qty": 1.0, "strategy": "TEST"}
+    pm.open_position(order)
+    with open(pm.positions_file, "r", encoding="utf-8") as f:
+        data = json.load(f)
+    assert data and data[0]["strategy"] == "TEST"
 

--- a/tests/test_signal.py
+++ b/tests/test_signal.py
@@ -67,6 +67,20 @@ def test_f2_signal_buy_trigger():
     )
     assert "buy_signal" in result
 
+
+@pytest.mark.skipif(not pandas_available, reason="pandas not available")
+def test_f2_signal_disable_all():
+    df = pd.DataFrame({
+        "timestamp": pd.date_range("2021-01-01", periods=30, freq="T"),
+        "open": np.linspace(1, 30, 30),
+        "high": np.linspace(1.1, 30.1, 30),
+        "low": np.linspace(0.9, 29.9, 30),
+        "close": np.linspace(1, 30, 30),
+        "volume": np.full(30, 100),
+    })
+    result = f2_signal(df, df, symbol="NONE", calc_buy=False, calc_sell=False)
+    assert not result["buy_signal"] and not result["sell_signal"]
+
 @pytest.mark.skipif(not pandas_available, reason="pandas not available")
 def test_eval_formula_numeric_comparison():
     row = pd.Series({"close": 10, "EMA_5": 9})


### PR DESCRIPTION
## Summary
- control buy/sell evaluation in `f2_signal` via `calc_buy`/`calc_sell`
- evaluate buy signals only for symbols from `current_universe.json`
- record strategy persistence in tests
- document separation of buy and sell monitoring

## Testing
- `pytest -q`