### PR TITLE
Switch to epoch timestamps

### DIFF
--- a/doc/overview.md
+++ b/doc/overview.md
@@ -53,3 +53,4 @@ The risk configuration also defines a `HOLD_SECS` value. When a position has
 been open for this many seconds the generic stop-loss, take-profit and
 trailing stop rules from the "손절/익절/TS 조건" card take precedence over the
 strategy-specific formula. This helps prevent very long holds.
+Positions now store their entry time as a numeric epoch timestamp rather than an ISO string.

--- a/f3_order/utils.py
+++ b/f3_order/utils.py
@@ -2,7 +2,7 @@
 [F3] 공용 유틸리티 (config 로더, 시간 등)
 """
 import json
-import datetime
+import time
 import logging
 from logging.handlers import RotatingFileHandler
 import os
@@ -60,8 +60,8 @@ def load_config(path):
         return {}
 
 def now():
-    """ 현재 UTC+9(한국) 타임스탬프 반환 (isoformat) """
-    return (datetime.datetime.utcnow() + datetime.timedelta(hours=9)).isoformat()
+    """Return current epoch timestamp as a floating point number."""
+    return time.time()
 
 def log_with_tag(logger, msg):
     """ [F3] 태그 붙여 로그 기록 """

--- a/tests/test_hold_time.py
+++ b/tests/test_hold_time.py
@@ -1,0 +1,51 @@
+import os
+import sys
+import time
+
+sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), "..")))
+
+from f3_order.position_manager import PositionManager
+from f3_order.kpi_guard import KPIGuard
+from f3_order.exception_handler import ExceptionHandler
+
+
+class DummyClient:
+    def place_order(self, *args, **kwargs):
+        return {"uuid": "1", "state": "done", "side": kwargs.get("side"), "volume": kwargs.get("volume", 0)}
+
+    def get_accounts(self):
+        return []
+
+    def ticker(self, markets):
+        return [{"market": m, "trade_price": 100.0} for m in markets]
+
+
+def make_pm(tmp_path, monkeypatch):
+    monkeypatch.setattr("f3_order.position_manager.UpbitClient", lambda: DummyClient())
+    cfg = {
+        "DB_PATH": os.path.join(tmp_path, "orders.db"),
+        "HOLD_SECS": 1,
+        "TP_PCT": 100,
+        "SL_PCT": 100,
+    }
+    return PositionManager(cfg, {}, KPIGuard({}), ExceptionHandler({"SLIP_MAX": 0.15}))
+
+
+def test_hold_loop_respects_hold_secs(tmp_path, monkeypatch):
+    pm = make_pm(tmp_path, monkeypatch)
+    pm.open_position({"symbol": "KRW-BTC", "price": 100.0, "qty": 1.0})
+    pos = pm.positions[0]
+    pos["current_price"] = 100.0
+    pos["entry_time"] = time.time() - 2
+
+    calls = {"trail": 0, "pyr": 0, "avg": 0}
+    monkeypatch.setattr(pm, "manage_trailing_stop", lambda p: calls.__setitem__("trail", calls["trail"] + 1))
+    monkeypatch.setattr(pm, "process_pyramiding", lambda p: calls.__setitem__("pyr", calls["pyr"] + 1))
+    monkeypatch.setattr(pm, "process_averaging_down", lambda p: calls.__setitem__("avg", calls["avg"] + 1))
+
+    pm.hold_loop()
+
+    assert calls["trail"] == 1
+    assert calls["pyr"] == 0
+    assert calls["avg"] == 0
+


### PR DESCRIPTION
## Summary
- return float timestamps from `f3_order.utils.now`
- record numeric `entry_time` when opening positions
- describe numeric timestamps in docs
- add unit test covering hold time logic
- normalize newline in `coin_positions.json`

## Testing
- `pytest -q`