### PR TITLE
Run hold loop each cycle

### DIFF
--- a/app.py
+++ b/app.py
@@ -168,6 +168,7 @@ def start_monitoring() -> None:
             ]
             rm.update_account(0.0, 0.0, 0.0, open_syms)
             rm.periodic()
+            _default_executor.manage_positions()
             time.sleep(1)
 
     _monitor_thread = threading.Thread(target=monitor_worker, daemon=True)

--- a/doc/overview.md
+++ b/doc/overview.md
@@ -14,7 +14,9 @@ This repository implements a four stage trading system built around the Upbit ex
 - **F3 Order Executor** – receives signals and places orders using the Upbit API.
   It maintains open positions, handles slippage and keeps a SQLite order log. When
   linked to the Risk Manager the executor mirrors updated sizing parameters like
-  `ENTRY_SIZE_INITIAL` whenever the risk configuration reloads.
+  `ENTRY_SIZE_INITIAL` whenever the risk configuration reloads. The executor's
+  `manage_positions()` routine (internally running `hold_loop`) is invoked on every
+  cycle of the signal loop and also when the application runs in monitoring mode.
 - **F4 Risk Manager** – enforces drawdown limits and other protections. It can pause
   or halt trading when risk thresholds are breached.
 - **F5 Machine Learning Pipeline** – trains and evaluates ML models used for

--- a/signal_loop.py
+++ b/signal_loop.py
@@ -137,6 +137,7 @@ def main_loop(interval: int = 1, stop_event=None) -> None:
                 process_symbol(symbol)
             except Exception as exc:  # pragma: no cover - best effort
                 logging.error(f"[{symbol}] Processing error: {exc}")
+        executor.manage_positions()
         time.sleep(interval)
 
 

--- a/tests/test_manage_positions.py
+++ b/tests/test_manage_positions.py
@@ -1,0 +1,79 @@
+import threading
+
+import pytest
+
+
+
+def dummy_risk_manager(*args, **kwargs):
+    class RM:
+        def update_account(self, *a, **k):
+            pass
+        def periodic(self):
+            pass
+    return RM()
+
+
+def test_main_loop_invokes_hold_loop(monkeypatch):
+    import importlib, sys, types
+
+    pyupbit = types.ModuleType("pyupbit")
+    pyupbit.get_ohlcv = lambda *a, **k: None
+    sys.modules["pyupbit"] = pyupbit
+    stub = types.ModuleType("signal_engine")
+    stub.f2_signal = lambda *a, **k: {}
+    stub.reload_strategy_settings = lambda: None
+    sys.modules["f2_signal.signal_engine"] = stub
+
+    import signal_loop
+    importlib.reload(signal_loop)
+
+    calls = []
+    monkeypatch.setattr(signal_loop._default_executor, "update_from_risk_config", lambda: None)
+    monkeypatch.setattr(signal_loop._default_executor.position_manager, "sync_with_universe", lambda u: None)
+    monkeypatch.setattr(signal_loop._default_executor.position_manager, "hold_loop", lambda: calls.append("h"))
+    monkeypatch.setattr(signal_loop, "RiskManager", lambda *a, **k: dummy_risk_manager())
+    monkeypatch.setattr(signal_loop, "load_config", lambda: {})
+    monkeypatch.setattr(signal_loop, "select_universe", lambda cfg: [])
+    monkeypatch.setattr(signal_loop, "get_universe", lambda: [])
+    monkeypatch.setattr(signal_loop, "schedule_universe_updates", lambda *a, **k: None)
+    monkeypatch.setattr(signal_loop, "process_symbol", lambda *a, **k: None)
+    stop_event = threading.Event()
+    monkeypatch.setattr(signal_loop.time, "sleep", lambda x: stop_event.set())
+    signal_loop.main_loop(interval=0, stop_event=stop_event)
+    assert calls == ["h"]
+
+
+def test_monitor_worker_invokes_hold_loop(monkeypatch):
+    import importlib, sys, types
+
+    pyupbit = types.ModuleType("pyupbit")
+    pyupbit.get_ohlcv = lambda *a, **k: None
+    sys.modules["pyupbit"] = pyupbit
+    stub = types.ModuleType("signal_engine")
+    stub.f2_signal = lambda *a, **k: {}
+    stub.reload_strategy_settings = lambda: None
+    sys.modules["f2_signal.signal_engine"] = stub
+
+    import signal_loop
+    importlib.reload(signal_loop)
+
+    import app
+    app.stop_monitoring()
+    calls = []
+    monkeypatch.setattr(signal_loop._default_executor, "update_from_risk_config", lambda: None)
+    monkeypatch.setattr(signal_loop._default_executor.position_manager, "hold_loop", lambda: calls.append("h"))
+    monkeypatch.setattr(signal_loop, "RiskManager", lambda *a, **k: dummy_risk_manager())
+
+    class DummyThread:
+        def __init__(self, target=None, daemon=None):
+            self._target = target
+        def start(self):
+            self._target()
+        def is_alive(self):
+            return False
+    monkeypatch.setattr(app.threading, "Thread", DummyThread)
+    monkeypatch.setattr(app.time, "sleep", lambda x: app._monitor_stop.set())
+
+    app.start_monitoring()
+    assert calls == ["h"]
+    app.stop_monitoring()


### PR DESCRIPTION
## Summary
- trigger `manage_positions()` before sleeping in `signal_loop.main_loop`
- call `manage_positions()` in monitoring loop
- document the new behaviour
- test that the hold loop runs once per iteration

## Testing
- `pytest -q`