### PR TITLE
Fix SellQty division and add regression test

### DIFF
--- a/doc/sellqty_handling.md
+++ b/doc/sellqty_handling.md
@@ -1,0 +1,7 @@
+# SellQty_5m Zero Handling
+
+The `eval_formula` helper now guards against division by zero when `SellQty_5m`
+values are missing or zero. Any occurrence of `SellQty_5m` in a formula is
+replaced with an expression that defaults to a tiny epsilon (`1e-8`) when the
+actual value is zero. This prevents runtime errors in strategy expressions like
+HYUN's buy rule which divide by `SellQty_5m`.

--- a/f2_signal/signal_engine.py
+++ b/f2_signal/signal_engine.py
@@ -635,7 +635,12 @@ def eval_formula(
                     expr = re.sub(re.escape(m.group(0)), replacement_val, expr)
             # After handling any function-like occurrences, replace plain mentions
             if key in data_row:
-                replacement_val = "0" if pd.isna(data_row[key]) else f"{float(data_row[key])}"
+                if key == "SellQty_5m":
+                    val = data_row[key]
+                    val = 0 if pd.isna(val) else float(val)
+                    replacement_val = f"({val} if {val} != 0 else 1e-8)"
+                else:
+                    replacement_val = "0" if pd.isna(data_row[key]) else f"{float(data_row[key])}"
                 expr = re.sub(rf"\b{re.escape(key)}\b", replacement_val, expr)
     # Replace basic fields after indicators (to avoid partial replacement issues)
     for name, val in replacements.items():

--- a/tests/test_signal.py
+++ b/tests/test_signal.py
@@ -99,6 +99,33 @@ def test_eval_formula_with_offset():
 
 
 @pytest.mark.skipif(not pandas_available, reason="pandas not available")
+def test_eval_formula_hyun_zero_division():
+    hyun_formula = (
+        "((EMA(5) > EMA(20) and EMA(20) > EMA(60) and (EMA(20) - EMA(20,-1)) / EMA(20,-1) > 0) * 25 + "
+        "(ATR(14) / Close * 100 >= 5) * 15 + "
+        "((ATR(14) / Close * 100 >= 1 and ATR(14) / Close * 100 < 5)) * 10 + "
+        "(Vol(0) >= MA(Vol,20) * 2) * 15 + "
+        "(Vol(0) >= MA(Vol,20) * 1.1) * 10 + "
+        "(BuyQty_5m / SellQty_5m * 100 >= 120) * 15 + "
+        "(BuyQty_5m / SellQty_5m * 100 >= 105) * 10 + "
+        "((EMA(5,-1) < EMA(20,-1)) and (EMA(5) > EMA(20))) * 5 + "
+        "(RSI(14) < 30) * 5 + "
+        "((RSI(14) >= 30 and RSI(14) < 40)) * 3) >= 45"
+    )
+    row = pd.Series({
+        "close": 10,
+        "open": 10,
+        "high": 10,
+        "low": 10,
+        "volume": 100,
+        "BuyQty_5m": 50,
+        "SellQty_5m": 0.0,
+    })
+    result = eval_formula(hyun_formula, row)
+    assert isinstance(result, bool)
+
+
+@pytest.mark.skipif(not pandas_available, reason="pandas not available")
 def test_f2_signal_requires_synced_candles():
     df1 = pd.DataFrame({
         "timestamp": pd.date_range("2021-01-01 00:00", periods=25, freq="T"),


### PR DESCRIPTION
## Summary
- avoid zero division when evaluating `SellQty_5m` in formulas
- test HYUN formula when sell quantity is zero
- document handling of `SellQty_5m` zero values

## Testing
- `pytest -q`