### PR TITLE
Propagate strategy during position import

### DIFF
--- a/doc/overview.md
+++ b/doc/overview.md
@@ -50,6 +50,10 @@ coins are being monitored even after restarting the application. The
 `PositionManager` reloads this file at startup so any open positions continue
 to be tracked across restarts.
 
+Positions detected in the exchange account when the application boots are
+registered with the strategy value `"imported"` so they can be distinguished
+from positions opened by automated signals.
+
 Each position stores the strategy code used on entry. During the signal loop
 only buy rules are evaluated for symbols from `current_universe.json`. Once a
 position is opened its associated `sell_formula` from

--- a/f3_order/position_manager.py
+++ b/f3_order/position_manager.py
@@ -127,6 +127,7 @@ class PositionManager:
                         "price": price,
                         "qty": bal,
                         "origin": "imported",
+                        "strategy": "imported",
                     })
                 log_data.update({"event": "ImportPosition", "origin": "imported", "action": "매도 시그널 감시 시작"})
                 imported.append(f"{symbol}({int(eval_amt):,}원)")

--- a/tests/test_position_import.py
+++ b/tests/test_position_import.py
@@ -1,5 +1,6 @@
 import os
 import sys
+import json
 sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), "..")))
 
 from f3_order.position_manager import PositionManager
@@ -31,3 +32,7 @@ def test_import_existing_positions(tmp_path, monkeypatch):
     assert len(pm.positions) == 1
     assert pm.positions[0]["symbol"] == "KRW-XRP"
     assert pm.positions[0]["origin"] == "imported"
+    assert pm.positions[0]["strategy"] == "imported"
+    with open(cfg["POSITIONS_FILE"], "r", encoding="utf-8") as f:
+        data = json.load(f)
+    assert data and data[0]["strategy"] == "imported"


### PR DESCRIPTION
## Summary
- ensure imported positions include `strategy` field
- record the imported strategy in holdings documentation
- test for strategy persistence when importing positions

## Testing
- `pytest -q`